### PR TITLE
An 2766/decoder history

### DIFF
--- a/.github/workflows/dbt_run_streamline_decoder.yml
+++ b/.github/workflows/dbt_run_streamline_decoder.yml
@@ -41,4 +41,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder
+          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history

--- a/.github/workflows/dbt_run_streamline_decoder_history.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history.yml
@@ -1,0 +1,41 @@
+name: dbt_run_streamline_decoder_history
+run-name: dbt_run_streamline_decoder_history
+
+on:
+  workflow_dispatch:
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.7.x"
+
+      - name: install dependencies
+        run: |
+          pip3 install dbt-snowflake==${{ vars.DBT_VERSION }} cli_passthrough requests click
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder/history

--- a/.github/workflows/dbt_run_streamline_decoder_history.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history.yml
@@ -3,6 +3,8 @@ run-name: dbt_run_streamline_decoder_history
 
 on:
   workflow_dispatch:
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./

--- a/macros/streamline/models.sql
+++ b/macros/streamline/models.sql
@@ -1,0 +1,54 @@
+{% macro decode_logs_history(
+        start,
+        stop
+    ) %}
+    WITH look_back AS (
+        SELECT
+            block_number
+        FROM
+            {{ ref("_max_block_by_date") }}
+            qualify ROW_NUMBER() over (
+                ORDER BY
+                    block_number DESC
+            ) = 1
+    )
+SELECT
+    l.block_number,
+    l._log_id,
+    abi.data AS abi,
+    l.data
+FROM
+    {{ ref("streamline__decode_logs") }}
+    l
+    INNER JOIN {{ ref("silver__abis") }}
+    abi
+    ON l.abi_address = abi.contract_address
+WHERE
+    (
+        l.block_number BETWEEN {{ start }}
+        AND {{ stop }}
+    )
+    AND l.block_number <= (
+        SELECT
+            block_number
+        FROM
+            look_back
+    )
+    AND _log_id NOT IN (
+        SELECT
+            _log_id
+        FROM
+            {{ ref("streamline__complete_decode_logs") }}
+        WHERE
+            (
+                block_number BETWEEN {{ start }}
+                AND {{ stop }}
+            )
+            AND block_number <= (
+                SELECT
+                    block_number
+                FROM
+                    look_back
+            )
+    )
+{% endmacro %}

--- a/macros/utils.sql
+++ b/macros/utils.sql
@@ -33,3 +33,46 @@
         NULL
     {% endif %}
 {% endmacro %}
+
+{% macro if_data_call_wait() %}
+    {% if var(
+            "STREAMLINE_INVOKE_STREAMS"
+        ) %}
+        {% set query %}
+    SELECT
+        1
+    WHERE
+        EXISTS(
+            SELECT
+                1
+            FROM
+                {{ model.schema ~ "." ~ model.alias }}
+            LIMIT
+                1
+        ) {% endset %}
+        {% if execute %}
+            {% set results = run_query(
+                query
+            ) %}
+            {% if results %}
+                {{ log(
+                    "Waiting...",
+                    info = True
+                ) }}
+
+                {% set wait_query %}
+            SELECT
+                system$wait(
+                    {{ var(
+                        "WAIT",
+                        600
+                    ) }}
+                ) {% endset %}
+                {% do run_query(wait_query) %}
+            {% else %}
+            SELECT
+                NULL;
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018000000_018033988.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018000000_018033988.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018000000_018033988.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018000000_018033988.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018033989_018068398.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018033989_018068398.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018033989_018068398.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018033989_018068398.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018068399_018102608.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018068399_018102608.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018068399_018102608.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018068399_018102608.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018102609_018138193.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018102609_018138193.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018102609_018138193.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018102609_018138193.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018138194_018173350.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018138194_018173350.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018138194_018173350.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018138194_018173350.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018173351_018207096.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018173351_018207096.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018173351_018207096.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018173351_018207096.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018207097_018240316.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018207097_018240316.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018207097_018240316.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018207097_018240316.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018240317_018275112.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018240317_018275112.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018240317_018275112.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018240317_018275112.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018275113_018309376.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018275113_018309376.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018275113_018309376.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018275113_018309376.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018309378_018345884.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018309378_018345884.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018309378_018345884.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018309378_018345884.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018345885_018381064.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018345885_018381064.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018345885_018381064.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018345885_018381064.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018381065_018414021.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018381065_018414021.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018381065_018414021.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018381065_018414021.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018414022_018448092.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018414022_018448092.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018414022_018448092.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018414022_018448092.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018448093_018486234.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018448093_018486234.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018448093_018486234.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018448093_018486234.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018486235_018519931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018486235_018519931.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018486235_018519931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018486235_018519931.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018519932_018552134.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018519932_018552134.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018519932_018552134.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018519932_018552134.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018552135_018584608.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018552135_018584608.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018552135_018584608.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018552135_018584608.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018584609_018615254.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018584609_018615254.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018584609_018615254.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018584609_018615254.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018615255_018646538.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018615255_018646538.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018615255_018646538.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018615255_018646538.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018646539_018680607.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018646539_018680607.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018646539_018680607.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018646539_018680607.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018680608_018712564.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018680608_018712564.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018680608_018712564.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018680608_018712564.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018712565_018744752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018712565_018744752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018712565_018744752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018712565_018744752.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018744753_018777752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018744753_018777752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018744753_018777752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018744753_018777752.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018777753_018810823.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018777753_018810823.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018777753_018810823.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018777753_018810823.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018810824_018843193.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018810824_018843193.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018810824_018843193.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018810824_018843193.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018843194_018874644.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018843194_018874644.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018843194_018874644.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018843194_018874644.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018874645_018905821.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018874645_018905821.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018874645_018905821.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018874645_018905821.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018905822_018937298.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018905822_018937298.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018905822_018937298.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018905822_018937298.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018937299_018968683.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018937299_018968683.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018937299_018968683.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018937299_018968683.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018968684_019001620.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018968684_019001620.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_018968684_019001620.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_018968684_019001620.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019001621_019034917.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019001621_019034917.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019001621_019034917.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019001621_019034917.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019034918_019067964.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019034918_019067964.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019034918_019067964.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019034918_019067964.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019067965_019102820.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019067965_019102820.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019067965_019102820.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019067965_019102820.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019102821_019137657.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019102821_019137657.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019102821_019137657.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019102821_019137657.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019137658_019172081.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019137658_019172081.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019137658_019172081.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019137658_019172081.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019172082_019205964.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019172082_019205964.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019172082_019205964.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019172082_019205964.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019205965_019237851.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019205965_019237851.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019205965_019237851.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019205965_019237851.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019237852_019273465.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019237852_019273465.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019237852_019273465.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019237852_019273465.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019273466_019306791.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019273466_019306791.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019273466_019306791.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019273466_019306791.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019306793_019339271.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019306793_019339271.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019306793_019339271.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019306793_019339271.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019339272_019371432.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019339272_019371432.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019339272_019371432.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019339272_019371432.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019371433_019403393.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019371433_019403393.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019371433_019403393.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019371433_019403393.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019403394_019432565.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019403394_019432565.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019403394_019432565.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019403394_019432565.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019432567_019462696.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019432567_019462696.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019432567_019462696.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019432567_019462696.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019462697_019493593.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019462697_019493593.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019462697_019493593.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019462697_019493593.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019493594_019523242.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019493594_019523242.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019493594_019523242.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019493594_019523242.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019523243_019550605.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019523243_019550605.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019523243_019550605.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019523243_019550605.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019550606_019576367.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019550606_019576367.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019550606_019576367.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019550606_019576367.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019576368_019605896.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019576368_019605896.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019576368_019605896.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019576368_019605896.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019605897_019634909.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019605897_019634909.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019605897_019634909.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019605897_019634909.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019634910_019663093.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019634910_019663093.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019634910_019663093.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019634910_019663093.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019663094_019691616.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019663094_019691616.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019663094_019691616.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019663094_019691616.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019691617_019723019.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019691617_019723019.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019691617_019723019.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019691617_019723019.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019723020_019754500.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019723020_019754500.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019723020_019754500.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019723020_019754500.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019754501_019782833.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019754501_019782833.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019754501_019782833.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019754501_019782833.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019782834_019811231.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019782834_019811231.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019782834_019811231.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019782834_019811231.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019811232_019835326.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019811232_019835326.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019811232_019835326.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019811232_019835326.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019835327_019863332.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019835327_019863332.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019835327_019863332.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019835327_019863332.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019863333_019900098.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019863333_019900098.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019863333_019900098.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019863333_019900098.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019900099_019940168.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019900099_019940168.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019900099_019940168.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019900099_019940168.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019940169_019983632.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019940169_019983632.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019940169_019983632.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019940169_019983632.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019983635_020030650.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019983635_020030650.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_019983635_020030650.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_019983635_020030650.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020030651_020077251.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020030651_020077251.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020030651_020077251.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020030651_020077251.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020077253_020105564.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020077253_020105564.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020077253_020105564.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020077253_020105564.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020105565_020141357.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020105565_020141357.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020105565_020141357.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020105565_020141357.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020141358_020178773.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020141358_020178773.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020141358_020178773.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020141358_020178773.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020178774_020220120.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020178774_020220120.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020178774_020220120.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020178774_020220120.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020220125_020261379.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020220125_020261379.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020220125_020261379.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020220125_020261379.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020261380_020300935.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020261380_020300935.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020261380_020300935.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020261380_020300935.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020300936_020334859.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020300936_020334859.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020300936_020334859.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020300936_020334859.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020334860_020359818.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020334860_020359818.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020334860_020359818.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020334860_020359818.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020359819_020389784.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020359819_020389784.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020359819_020389784.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020359819_020389784.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020389785_020427565.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020389785_020427565.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020389785_020427565.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020389785_020427565.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020427566_020467866.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020427566_020467866.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020427566_020467866.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020427566_020467866.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020467867_020507226.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020467867_020507226.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020467867_020507226.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020467867_020507226.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020507227_020549224.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020507227_020549224.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020507227_020549224.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020507227_020549224.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020549225_020582976.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020549225_020582976.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020549225_020582976.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020549225_020582976.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020582977_020610910.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020582977_020610910.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020582977_020610910.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020582977_020610910.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020610911_020643557.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020610911_020643557.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020610911_020643557.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020610911_020643557.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020643558_020675261.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020643558_020675261.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020643558_020675261.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020643558_020675261.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020675262_020708365.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020675262_020708365.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020675262_020708365.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020675262_020708365.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020708366_020741846.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020708366_020741846.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020708366_020741846.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020708366_020741846.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020741847_020779803.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020741847_020779803.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020741847_020779803.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020741847_020779803.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020779804_020822801.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020779804_020822801.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020779804_020822801.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020779804_020822801.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020822802_020854058.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020822802_020854058.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020822802_020854058.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020822802_020854058.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020854059_020888077.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020854059_020888077.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020854059_020888077.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020854059_020888077.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020888078_020925444.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020888078_020925444.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020888078_020925444.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020888078_020925444.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020925445_020964246.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020925445_020964246.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020925445_020964246.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020925445_020964246.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020964247_021010752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020964247_021010752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_020964247_021010752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_020964247_021010752.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021010753_021056656.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021010753_021056656.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021010753_021056656.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021010753_021056656.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021056657_021105801.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021056657_021105801.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021056657_021105801.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021056657_021105801.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021105802_021131028.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021105802_021131028.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021105802_021131028.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021105802_021131028.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021131029_021151411.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021131029_021151411.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021131029_021151411.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021131029_021151411.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021151412_021184691.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021151412_021184691.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021151412_021184691.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021151412_021184691.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021184692_021224698.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021184692_021224698.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021184692_021224698.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021184692_021224698.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021224699_021262677.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021224699_021262677.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021224699_021262677.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021224699_021262677.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021262678_021299928.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021262678_021299928.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021262678_021299928.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021262678_021299928.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021299929_021342136.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021299929_021342136.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021299929_021342136.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021299929_021342136.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021342137_021382497.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021342137_021382497.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021342137_021382497.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021342137_021382497.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021382498_021412676.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021382498_021412676.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021382498_021412676.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021382498_021412676.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021412677_021446252.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021412677_021446252.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021412677_021446252.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021412677_021446252.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021446253_021484556.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021446253_021484556.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021446253_021484556.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021446253_021484556.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021484557_021523894.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021484557_021523894.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021484557_021523894.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021484557_021523894.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021523895_021564923.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021523895_021564923.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021523895_021564923.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021523895_021564923.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021564924_021606501.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021564924_021606501.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021564924_021606501.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021564924_021606501.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021606502_021650360.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021606502_021650360.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021606502_021650360.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021606502_021650360.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021650361_021676816.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021650361_021676816.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021650361_021676816.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021650361_021676816.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021676817_021710238.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021676817_021710238.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021676817_021710238.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021676817_021710238.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021710239_021744493.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021710239_021744493.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021710239_021744493.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021710239_021744493.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021744494_021779200.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021744494_021779200.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021744494_021779200.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021744494_021779200.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021779201_021814701.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021779201_021814701.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021779201_021814701.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021779201_021814701.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021814702_021850314.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021814702_021850314.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021814702_021850314.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021814702_021850314.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021850315_021887315.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021850315_021887315.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021850315_021887315.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021850315_021887315.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021887316_021921029.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021887316_021921029.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021887316_021921029.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021887316_021921029.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021921030_021945274.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021921030_021945274.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021921030_021945274.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021921030_021945274.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021945275_021978166.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021945275_021978166.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021945275_021978166.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021945275_021978166.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021978167_022014316.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021978167_022014316.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_021978167_022014316.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_021978167_022014316.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022014317_022047189.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022014317_022047189.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022014317_022047189.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022014317_022047189.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022047190_022082982.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022047190_022082982.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022047190_022082982.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022047190_022082982.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022082983_022116220.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022082983_022116220.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022082983_022116220.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022082983_022116220.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022116221_022152212.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022116221_022152212.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022116221_022152212.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022116221_022152212.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022152213_022191859.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022152213_022191859.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022152213_022191859.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022152213_022191859.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022191860_022222000.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022191860_022222000.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022191860_022222000.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022191860_022222000.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022222001_022262928.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022222001_022262928.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022222001_022262928.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022222001_022262928.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022262929_022305119.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022262929_022305119.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022262929_022305119.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022262929_022305119.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022305120_022343937.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022305120_022343937.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022305120_022343937.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022305120_022343937.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022343938_022383749.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022343938_022383749.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022343938_022383749.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022343938_022383749.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022383750_022425794.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022383750_022425794.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022383750_022425794.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022383750_022425794.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022425795_022464436.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022425795_022464436.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022425795_022464436.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022425795_022464436.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022464437_022497677.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022464437_022497677.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022464437_022497677.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022464437_022497677.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022497678_022533853.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022497678_022533853.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022497678_022533853.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022497678_022533853.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022533854_022573303.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022533854_022573303.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022533854_022573303.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022533854_022573303.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022573304_022617882.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022573304_022617882.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022573304_022617882.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022573304_022617882.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022617883_022663825.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022617883_022663825.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022617883_022663825.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022617883_022663825.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022663826_022711667.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022663826_022711667.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022663826_022711667.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022663826_022711667.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022711668_022747009.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022711668_022747009.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022711668_022747009.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022711668_022747009.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022747010_022786690.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022747010_022786690.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022747010_022786690.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022747010_022786690.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022786691_022828631.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022786691_022828631.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022786691_022828631.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022786691_022828631.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022828633_022871238.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022828633_022871238.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022828633_022871238.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022828633_022871238.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022871239_022914698.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022871239_022914698.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022871239_022914698.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022871239_022914698.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022914699_022965195.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022914699_022965195.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022914699_022965195.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022914699_022965195.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022965196_023010039.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022965196_023010039.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_022965196_023010039.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_022965196_023010039.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023010040_023047007.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023010040_023047007.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023010040_023047007.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023010040_023047007.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023047008_023085934.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023047008_023085934.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023047008_023085934.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023047008_023085934.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023085935_023126163.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023085935_023126163.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023085935_023126163.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023085935_023126163.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023126164_023169342.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023126164_023169342.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023126164_023169342.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023126164_023169342.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023169343_023216326.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023169343_023216326.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023169343_023216326.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023169343_023216326.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023216327_023261424.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023216327_023261424.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023216327_023261424.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023216327_023261424.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023261425_023302198.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023261425_023302198.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023261425_023302198.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023261425_023302198.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023302199_023344715.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023302199_023344715.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023302199_023344715.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023302199_023344715.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023344716_023392444.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023344716_023392444.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023344716_023392444.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023344716_023392444.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023392445_023442044.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023392445_023442044.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023392445_023442044.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023392445_023442044.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023442045_023498612.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023442045_023498612.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023442045_023498612.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023442045_023498612.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023498613_023556905.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023498613_023556905.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023498613_023556905.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023498613_023556905.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023556906_023606870.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023556906_023606870.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023556906_023606870.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023556906_023606870.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023606871_023651618.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023606871_023651618.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023606871_023651618.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023606871_023651618.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023651619_023700468.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023651619_023700468.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023651619_023700468.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023651619_023700468.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023700469_023729634.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023700469_023729634.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023700469_023729634.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023700469_023729634.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023729635_023768570.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023729635_023768570.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023729635_023768570.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023729635_023768570.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023768571_023823285.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023768571_023823285.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023768571_023823285.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023768571_023823285.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023823286_023883820.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023823286_023883820.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023823286_023883820.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023823286_023883820.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023883821_023952064.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023883821_023952064.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023883821_023952064.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023883821_023952064.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023952065_024014799.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023952065_024014799.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_023952065_024014799.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_023952065_024014799.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024014800_024076397.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024014800_024076397.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024014800_024076397.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024014800_024076397.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024076398_024138906.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024076398_024138906.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024076398_024138906.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024076398_024138906.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024138907_024198346.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024138907_024198346.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024138907_024198346.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024138907_024198346.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024198347_024252253.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024198347_024252253.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024198347_024252253.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024198347_024252253.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024252254_024305883.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024252254_024305883.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024252254_024305883.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024252254_024305883.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024305884_024362142.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024305884_024362142.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024305884_024362142.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024305884_024362142.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024362143_024418687.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024362143_024418687.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024362143_024418687.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024362143_024418687.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024418688_024473861.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024418688_024473861.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024418688_024473861.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024418688_024473861.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024473862_024523852.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024473862_024523852.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024473862_024523852.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024473862_024523852.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024523853_024575645.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024523853_024575645.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024523853_024575645.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024523853_024575645.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024575646_024633165.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024575646_024633165.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024575646_024633165.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024575646_024633165.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024633166_024684433.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024633166_024684433.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024633166_024684433.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024633166_024684433.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024684434_024736086.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024684434_024736086.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024684434_024736086.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024684434_024736086.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024736087_024786093.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024736087_024786093.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024736087_024786093.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024736087_024786093.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024786094_024836807.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024786094_024836807.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024786094_024836807.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024786094_024836807.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024836808_024893271.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024836808_024893271.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024836808_024893271.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024836808_024893271.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024893272_024943538.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024893272_024943538.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024893272_024943538.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024893272_024943538.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024943539_024996931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024943539_024996931.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024943539_024996931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024943539_024996931.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024996932_025054945.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024996932_025054945.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_024996932_025054945.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_024996932_025054945.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025054946_025116465.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025054946_025116465.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025054946_025116465.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025054946_025116465.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025116466_025187397.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025116466_025187397.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025116466_025187397.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025116466_025187397.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025187398_025248334.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025187398_025248334.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025187398_025248334.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025187398_025248334.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025248335_025310122.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025248335_025310122.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025248335_025310122.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025248335_025310122.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025310123_025379840.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025310123_025379840.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025310123_025379840.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025310123_025379840.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025379843_025440547.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025379843_025440547.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025379843_025440547.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025379843_025440547.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025440548_025501364.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025440548_025501364.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025440548_025501364.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025440548_025501364.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025501365_025570502.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025501365_025570502.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025501365_025570502.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025501365_025570502.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025570503_025642371.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025570503_025642371.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025570503_025642371.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025570503_025642371.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025642372_025707507.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025642372_025707507.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025642372_025707507.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025642372_025707507.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025707508_025767295.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025707508_025767295.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025707508_025767295.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025707508_025767295.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025767296_025830785.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025767296_025830785.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025767296_025830785.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025767296_025830785.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025830786_025894744.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025830786_025894744.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025830786_025894744.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025830786_025894744.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025894745_025957183.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025894745_025957183.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025894745_025957183.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025894745_025957183.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025957184_026013695.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025957184_026013695.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_025957184_026013695.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_025957184_026013695.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026013696_026070239.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026013696_026070239.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026013696_026070239.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026013696_026070239.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026070240_026126460.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026070240_026126460.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026070240_026126460.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026070240_026126460.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026126461_026189082.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026126461_026189082.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026126461_026189082.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026126461_026189082.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026189083_026246922.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026189083_026246922.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026189083_026246922.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026189083_026246922.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026246923_026303059.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026246923_026303059.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026246923_026303059.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026246923_026303059.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026303060_026361040.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026303060_026361040.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026303060_026361040.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026303060_026361040.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026361041_026431181.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026361041_026431181.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026361041_026431181.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026361041_026431181.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026431182_026494299.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026431182_026494299.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026431182_026494299.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026431182_026494299.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026494300_026556423.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026494300_026556423.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026494300_026556423.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026494300_026556423.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026556424_026617255.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026556424_026617255.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026556424_026617255.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026556424_026617255.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026617256_026674840.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026617256_026674840.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026617256_026674840.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026617256_026674840.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026674841_026735074.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026674841_026735074.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026674841_026735074.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026674841_026735074.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026735075_026792747.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026735075_026792747.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026735075_026792747.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026735075_026792747.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026792748_026848979.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026792748_026848979.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026792748_026848979.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026792748_026848979.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026848980_026902745.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026848980_026902745.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026848980_026902745.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026848980_026902745.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026902746_026963812.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026902746_026963812.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026902746_026963812.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026902746_026963812.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026963813_027020407.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026963813_027020407.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_026963813_027020407.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_026963813_027020407.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027020408_027073446.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027020408_027073446.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027020408_027073446.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027020408_027073446.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027073447_027129016.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027073447_027129016.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027073447_027129016.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027073447_027129016.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027129017_027180005.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027129017_027180005.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027129017_027180005.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027129017_027180005.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027180006_027234815.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027180006_027234815.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027180006_027234815.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027180006_027234815.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027234816_027285795.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027234816_027285795.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027234816_027285795.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027234816_027285795.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027285796_027333072.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027285796_027333072.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027285796_027333072.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027285796_027333072.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027333073_027383168.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027333073_027383168.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027333073_027383168.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027333073_027383168.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027383169_027431552.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027383169_027431552.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027383169_027431552.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027383169_027431552.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027431553_027483931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027431553_027483931.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027431553_027483931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027431553_027483931.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027483932_027538100.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027483932_027538100.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027483932_027538100.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027483932_027538100.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027538101_027587327.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027538101_027587327.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027538101_027587327.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027538101_027587327.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027587328_027637310.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027587328_027637310.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027587328_027637310.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027587328_027637310.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027637311_027685357.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027637311_027685357.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027637311_027685357.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027637311_027685357.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027685358_027732137.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027685358_027732137.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027685358_027732137.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027685358_027732137.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027732138_027781585.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027732138_027781585.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027732138_027781585.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027732138_027781585.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027781586_027836749.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027781586_027836749.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027781586_027836749.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027781586_027836749.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027836750_027890117.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027836750_027890117.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027836750_027890117.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027836750_027890117.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027890118_027939411.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027890118_027939411.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027890118_027939411.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027890118_027939411.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027939412_027988434.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027939412_027988434.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027939412_027988434.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027939412_027988434.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027988435_028040854.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027988435_028040854.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_027988435_028040854.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_027988435_028040854.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028040855_028094257.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028040855_028094257.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028040855_028094257.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028040855_028094257.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028094258_028139752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028094258_028139752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028094258_028139752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028094258_028139752.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028139753_028190658.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028139753_028190658.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028139753_028190658.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028139753_028190658.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028190659_028235591.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028190659_028235591.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028190659_028235591.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028190659_028235591.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028235592_028281728.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028235592_028281728.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028235592_028281728.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028235592_028281728.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028281729_028336486.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028281729_028336486.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028281729_028336486.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028281729_028336486.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028336487_028393399.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028336487_028393399.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028336487_028393399.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028336487_028393399.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028393400_028452398.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028393400_028452398.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028393400_028452398.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028393400_028452398.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028452399_028506717.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028452399_028506717.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028452399_028506717.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028452399_028506717.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028506718_028562039.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028506718_028562039.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028506718_028562039.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028506718_028562039.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028562040_028626286.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028562040_028626286.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028562040_028626286.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028562040_028626286.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028626287_028685460.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028626287_028685460.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028626287_028685460.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028626287_028685460.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028685461_028744881.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028685461_028744881.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028685461_028744881.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028685461_028744881.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028744882_028799634.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028744882_028799634.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028744882_028799634.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028744882_028799634.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028799635_028854460.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028799635_028854460.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028799635_028854460.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028799635_028854460.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028854461_028919288.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028854461_028919288.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028854461_028919288.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028854461_028919288.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028919289_028981503.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028919289_028981503.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028919289_028981503.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028919289_028981503.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028981504_029039140.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028981504_029039140.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_028981504_029039140.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_028981504_029039140.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029039141_029101111.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029039141_029101111.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029039141_029101111.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029039141_029101111.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029101112_029163378.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029101112_029163378.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029101112_029163378.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029101112_029163378.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029163379_029226429.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029163379_029226429.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029163379_029226429.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029163379_029226429.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029226430_029284613.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029226430_029284613.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029226430_029284613.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029226430_029284613.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029284614_029344745.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029284614_029344745.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029284614_029344745.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029284614_029344745.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029344746_029402062.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029344746_029402062.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029344746_029402062.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029344746_029402062.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029402063_029462005.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029402063_029462005.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029402063_029462005.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029402063_029462005.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029462006_029516056.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029462006_029516056.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029462006_029516056.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029462006_029516056.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029516057_029564622.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029516057_029564622.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029516057_029564622.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029516057_029564622.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029564623_029614552.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029564623_029614552.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029564623_029614552.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029564623_029614552.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029614553_029667166.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029614553_029667166.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029614553_029667166.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029614553_029667166.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029667167_029725334.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029667167_029725334.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029667167_029725334.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029667167_029725334.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029725335_029780894.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029725335_029780894.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029725335_029780894.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029725335_029780894.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029780895_029834209.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029780895_029834209.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029780895_029834209.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029780895_029834209.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029834210_029889483.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029834210_029889483.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029834210_029889483.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029834210_029889483.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029889484_029941052.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029889484_029941052.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029889484_029941052.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029889484_029941052.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029941053_029990117.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029941053_029990117.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029941053_029990117.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029941053_029990117.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029990118_030047756.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029990118_030047756.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_029990118_030047756.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_029990118_030047756.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030047757_030098952.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030047757_030098952.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030047757_030098952.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030047757_030098952.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030098953_030152347.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030098953_030152347.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030098953_030152347.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030098953_030152347.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030152348_030206338.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030152348_030206338.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030152348_030206338.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030152348_030206338.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030206339_030268341.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030206339_030268341.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030206339_030268341.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030206339_030268341.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030268342_030331650.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030268342_030331650.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030268342_030331650.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030268342_030331650.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030331651_030385089.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030331651_030385089.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030331651_030385089.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030331651_030385089.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030385090_030443281.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030385090_030443281.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030385090_030443281.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030385090_030443281.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030443282_030505161.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030443282_030505161.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030443282_030505161.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030443282_030505161.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030505162_030575412.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030505162_030575412.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030505162_030575412.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030505162_030575412.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030575413_030637245.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030575413_030637245.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030575413_030637245.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030575413_030637245.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030637246_030692833.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030637246_030692833.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030637246_030692833.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030637246_030692833.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030692834_030743381.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030692834_030743381.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030692834_030743381.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030692834_030743381.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030743382_030797526.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030743382_030797526.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030743382_030797526.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030743382_030797526.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030797527_030854028.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030797527_030854028.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030797527_030854028.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030797527_030854028.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030854029_030903444.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030854029_030903444.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030854029_030903444.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030854029_030903444.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030903445_030958001.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030903445_030958001.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030903445_030958001.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030903445_030958001.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030958002_031008796.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030958002_031008796.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_030958002_031008796.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_030958002_031008796.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031008797_031065511.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031008797_031065511.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031008797_031065511.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031008797_031065511.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031065512_031123145.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031065512_031123145.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031065512_031123145.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031065512_031123145.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031123146_031179487.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031123146_031179487.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031123146_031179487.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031123146_031179487.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031179488_031238400.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031179488_031238400.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031179488_031238400.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031179488_031238400.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031238401_031293199.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031238401_031293199.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031238401_031293199.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031238401_031293199.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031293200_031351229.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031293200_031351229.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031293200_031351229.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031293200_031351229.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031351230_031411626.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031351230_031411626.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031351230_031411626.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031351230_031411626.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031411627_031476863.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031411627_031476863.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031411627_031476863.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031411627_031476863.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031476864_031537386.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031476864_031537386.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031476864_031537386.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031476864_031537386.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031537387_031597503.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031537387_031597503.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031537387_031597503.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031537387_031597503.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031597504_031657192.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031597504_031657192.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031597504_031657192.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031597504_031657192.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031657193_031715032.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031657193_031715032.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031657193_031715032.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031657193_031715032.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031715033_031768700.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031715033_031768700.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031715033_031768700.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031715033_031768700.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031768701_031826373.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031768701_031826373.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031768701_031826373.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031768701_031826373.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031826374_031883455.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031826374_031883455.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031826374_031883455.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031826374_031883455.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031883456_031940731.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031883456_031940731.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031883456_031940731.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031883456_031940731.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031940732_031996721.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031940732_031996721.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031940732_031996721.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031940732_031996721.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031996722_032052538.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031996722_032052538.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_031996722_032052538.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_031996722_032052538.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032052540_032107346.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032052540_032107346.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032052540_032107346.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032052540_032107346.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032107347_032170167.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032107347_032170167.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032107347_032170167.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032107347_032170167.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032170168_032225150.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032170168_032225150.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032170168_032225150.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032170168_032225150.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032225151_032281611.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032225151_032281611.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032225151_032281611.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032225151_032281611.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032281612_032340849.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032281612_032340849.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032281612_032340849.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032281612_032340849.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032340850_032397998.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032340850_032397998.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032340850_032397998.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032340850_032397998.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032397999_032456498.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032397999_032456498.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032397999_032456498.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032397999_032456498.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032456499_032507981.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032456499_032507981.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032456499_032507981.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032456499_032507981.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032507982_032564916.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032507982_032564916.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032507982_032564916.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032507982_032564916.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032564917_032635080.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032564917_032635080.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032564917_032635080.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032564917_032635080.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032635081_032710439.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032635081_032710439.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032635081_032710439.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032635081_032710439.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032710440_032775578.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032710440_032775578.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032710440_032775578.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032710440_032775578.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032775579_032841987.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032775579_032841987.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032775579_032841987.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032775579_032841987.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032841988_032906914.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032841988_032906914.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032841988_032906914.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032841988_032906914.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032906915_032980942.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032906915_032980942.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032906915_032980942.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032906915_032980942.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032980943_033049185.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032980943_033049185.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_032980943_033049185.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_032980943_033049185.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033049186_033116114.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033049186_033116114.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033049186_033116114.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033049186_033116114.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033116115_033180628.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033116115_033180628.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033116115_033180628.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033116115_033180628.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033180629_033256340.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033180629_033256340.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033180629_033256340.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033180629_033256340.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033256341_033322099.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033256341_033322099.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033256341_033322099.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033256341_033322099.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033322100_033387589.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033322100_033387589.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033322100_033387589.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033322100_033387589.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033387590_033447267.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033387590_033447267.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033387590_033447267.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033387590_033447267.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033447268_033510006.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033447268_033510006.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033447268_033510006.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033447268_033510006.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033510007_033580329.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033510007_033580329.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033510007_033580329.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033510007_033580329.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033580330_033634423.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033580330_033634423.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033580330_033634423.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033580330_033634423.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033634424_033690618.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033634424_033690618.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033634424_033690618.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033634424_033690618.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033690619_033748895.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033690619_033748895.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033690619_033748895.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033690619_033748895.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033748896_033814682.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033748896_033814682.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033748896_033814682.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033748896_033814682.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033814683_033875008.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033814683_033875008.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033814683_033875008.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033814683_033875008.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033875009_033935097.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033875009_033935097.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033875009_033935097.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033875009_033935097.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033935100_033995696.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033935100_033995696.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033935100_033995696.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033935100_033995696.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033995697_034054992.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033995697_034054992.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_033995697_034054992.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_033995697_034054992.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034054993_034116863.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034054993_034116863.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034054993_034116863.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034054993_034116863.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034116864_034175978.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034116864_034175978.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034116864_034175978.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034116864_034175978.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034175979_034236186.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034175979_034236186.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034175979_034236186.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034175979_034236186.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034236187_034300323.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034236187_034300323.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034236187_034300323.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034236187_034300323.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034300324_034373787.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034300324_034373787.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034300324_034373787.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034300324_034373787.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034373788_034445501.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034373788_034445501.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034373788_034445501.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034373788_034445501.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034445502_034515679.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034445502_034515679.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034445502_034515679.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034445502_034515679.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034515681_034596824.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034515681_034596824.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034515681_034596824.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034515681_034596824.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034596825_034676120.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034596825_034676120.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034596825_034676120.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034596825_034676120.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034676121_034753899.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034676121_034753899.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034676121_034753899.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034676121_034753899.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034753900_034826343.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034753900_034826343.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034753900_034826343.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034753900_034826343.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034826344_034894329.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034826344_034894329.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034826344_034894329.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034826344_034894329.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034894330_034960755.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034894330_034960755.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034894330_034960755.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034894330_034960755.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034960756_035027950.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034960756_035027950.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_034960756_035027950.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_034960756_035027950.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035027951_035094428.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035027951_035094428.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035027951_035094428.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035027951_035094428.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035094429_035158118.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035094429_035158118.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035094429_035158118.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035094429_035158118.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035158119_035218130.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035158119_035218130.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035158119_035218130.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035158119_035218130.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035218131_035278456.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035218131_035278456.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035218131_035278456.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035218131_035278456.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035278457_035340974.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035278457_035340974.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035278457_035340974.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035278457_035340974.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035340975_035396251.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035340975_035396251.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035340975_035396251.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035340975_035396251.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035396252_035442667.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035396252_035442667.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035396252_035442667.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035396252_035442667.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035442668_035492512.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035442668_035492512.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035442668_035492512.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035442668_035492512.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035492513_035550977.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035492513_035550977.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035492513_035550977.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035492513_035550977.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035550978_035608577.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035550978_035608577.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035550978_035608577.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035550978_035608577.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035608578_035668032.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035608578_035668032.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035608578_035668032.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035608578_035668032.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035668033_035727248.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035668033_035727248.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035668033_035727248.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035668033_035727248.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035727249_035787891.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035727249_035787891.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035727249_035787891.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035727249_035787891.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035787892_035848433.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035787892_035848433.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035787892_035848433.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035787892_035848433.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035848434_035904246.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035848434_035904246.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035848434_035904246.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035848434_035904246.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035904247_035961733.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035904247_035961733.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035904247_035961733.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035904247_035961733.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035961734_036017824.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035961734_036017824.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_035961734_036017824.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_035961734_036017824.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036017825_036076572.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036017825_036076572.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036017825_036076572.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036017825_036076572.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036076573_036135452.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036076573_036135452.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036076573_036135452.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036076573_036135452.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036135453_036194261.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036135453_036194261.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036135453_036194261.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036135453_036194261.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036194262_036250489.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036194262_036250489.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036194262_036250489.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036194262_036250489.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036250490_036302447.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036250490_036302447.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036250490_036302447.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036250490_036302447.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036302448_036357899.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036302448_036357899.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036302448_036357899.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036302448_036357899.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036357900_036410107.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036357900_036410107.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036357900_036410107.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036357900_036410107.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036410108_036463811.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036410108_036463811.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036410108_036463811.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036410108_036463811.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036463812_036523452.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036463812_036523452.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036463812_036523452.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036463812_036523452.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036523453_036578227.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036523453_036578227.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036523453_036578227.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036523453_036578227.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036578228_036628985.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036578228_036628985.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036578228_036628985.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036578228_036628985.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036628986_036687620.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036628986_036687620.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036628986_036687620.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036628986_036687620.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036687621_036744930.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036687621_036744930.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036687621_036744930.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036687621_036744930.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036744932_036797681.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036744932_036797681.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036744932_036797681.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036744932_036797681.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036797682_036849640.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036797682_036849640.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036797682_036849640.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036797682_036849640.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036849641_036902197.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036849641_036902197.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036849641_036902197.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036849641_036902197.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036902198_036954284.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036902198_036954284.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036902198_036954284.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036902198_036954284.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036954285_037009923.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036954285_037009923.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_036954285_037009923.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_036954285_037009923.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037009924_037061014.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037009924_037061014.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037009924_037061014.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037009924_037061014.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037061015_037114982.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037061015_037114982.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037061015_037114982.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037061015_037114982.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037114983_037173533.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037114983_037173533.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037114983_037173533.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037114983_037173533.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037173534_037234947.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037173534_037234947.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037173534_037234947.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037173534_037234947.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037234948_037298278.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037234948_037298278.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037234948_037298278.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037234948_037298278.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037298279_037358764.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037298279_037358764.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037298279_037358764.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037298279_037358764.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037358765_037415006.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037358765_037415006.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037358765_037415006.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037358765_037415006.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037415007_037471625.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037415007_037471625.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037415007_037471625.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037415007_037471625.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037471626_037536423.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037471626_037536423.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037471626_037536423.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037471626_037536423.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037536424_037603967.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037536424_037603967.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037536424_037603967.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037536424_037603967.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037603968_037660017.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037603968_037660017.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037603968_037660017.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037603968_037660017.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037660018_037714371.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037660018_037714371.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037660018_037714371.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037660018_037714371.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037714372_037770544.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037714372_037770544.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037714372_037770544.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037714372_037770544.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037770545_037828483.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037770545_037828483.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037770545_037828483.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037770545_037828483.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037828484_037884328.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037828484_037884328.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037828484_037884328.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037828484_037884328.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037884329_037943315.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037884329_037943315.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037884329_037943315.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037884329_037943315.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037943316_037997706.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037943316_037997706.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037943316_037997706.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037943316_037997706.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037997707_038054961.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037997707_038054961.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_037997707_038054961.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_037997707_038054961.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038054962_038111822.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038054962_038111822.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038054962_038111822.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038054962_038111822.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038111823_038169119.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038111823_038169119.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038111823_038169119.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038111823_038169119.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038169120_038223990.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038169120_038223990.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038169120_038223990.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038169120_038223990.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038223991_038276249.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038223991_038276249.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038223991_038276249.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038223991_038276249.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038276251_038330992.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038276251_038330992.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038276251_038330992.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038276251_038330992.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038330993_038387149.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038330993_038387149.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038330993_038387149.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038330993_038387149.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038387150_038440664.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038387150_038440664.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038387150_038440664.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038387150_038440664.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038440665_038496129.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038440665_038496129.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038440665_038496129.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038440665_038496129.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038496130_038550107.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038496130_038550107.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038496130_038550107.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038496130_038550107.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038550108_038599984.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038550108_038599984.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038550108_038599984.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038550108_038599984.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038599985_038652668.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038599985_038652668.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038599985_038652668.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038599985_038652668.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038652669_038704842.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038652669_038704842.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038652669_038704842.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038652669_038704842.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038704843_038752288.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038704843_038752288.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038704843_038752288.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038704843_038752288.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038752289_038800047.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038752289_038800047.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038752289_038800047.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038752289_038800047.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038800049_038849012.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038800049_038849012.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038800049_038849012.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038800049_038849012.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038849013_038900268.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038849013_038900268.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038849013_038900268.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038849013_038900268.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038900269_038952674.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038900269_038952674.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038900269_038952674.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038900269_038952674.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038952675_039005296.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038952675_039005296.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_038952675_039005296.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_038952675_039005296.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039005297_039057017.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039005297_039057017.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039005297_039057017.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039005297_039057017.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039057018_039108959.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039057018_039108959.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039057018_039108959.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039057018_039108959.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039108960_039162628.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039108960_039162628.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039108960_039162628.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039108960_039162628.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039162629_039221947.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039162629_039221947.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039162629_039221947.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039162629_039221947.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039221948_039278855.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039221948_039278855.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039221948_039278855.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039221948_039278855.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039278856_039336716.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039278856_039336716.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039278856_039336716.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039278856_039336716.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039336717_039393698.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039336717_039393698.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039336717_039393698.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039336717_039393698.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039393699_039454506.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039393699_039454506.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039393699_039454506.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039393699_039454506.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039454507_039514714.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039454507_039514714.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039454507_039514714.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039454507_039514714.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039514715_039564715.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039514715_039564715.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039514715_039564715.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039514715_039564715.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039564716_039614716.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039564716_039614716.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039564716_039614716.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039564716_039614716.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039614717_039664717.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039614717_039664717.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039614717_039664717.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039614717_039664717.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039664718_039714718.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039664718_039714718.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039664718_039714718.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039664718_039714718.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039714719_039764719.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039714719_039764719.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039714719_039764719.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039714719_039764719.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039764720_039814720.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039764720_039814720.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039764720_039814720.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039764720_039814720.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039814721_039864721.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039814721_039864721.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039814721_039864721.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039814721_039864721.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039864722_039914722.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039864722_039914722.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039864722_039914722.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039864722_039914722.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039914723_039964723.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039914723_039964723.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039914723_039964723.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039914723_039964723.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039964724_040014724.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039964724_040014724.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_039964724_040014724.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_039964724_040014724.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040014725_040064725.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040014725_040064725.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040014725_040064725.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040014725_040064725.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040064726_040114726.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040064726_040114726.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040064726_040114726.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040064726_040114726.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040114727_040164727.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040114727_040164727.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040114727_040164727.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040114727_040164727.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040164728_040214728.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040164728_040214728.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040164728_040214728.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040164728_040214728.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040214729_040264729.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040214729_040264729.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040214729_040264729.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040214729_040264729.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040264730_040314730.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040264730_040314730.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040264730_040314730.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040264730_040314730.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040314731_040364731.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040314731_040364731.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040314731_040364731.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040314731_040364731.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040364732_040414732.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040364732_040414732.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040364732_040414732.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040364732_040414732.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040414733_040464733.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040414733_040464733.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040414733_040464733.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040414733_040464733.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040464734_040514734.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040464734_040514734.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040464734_040514734.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040464734_040514734.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040514735_040564735.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040514735_040564735.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040514735_040564735.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040514735_040564735.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040564736_040614736.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040564736_040614736.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040564736_040614736.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040564736_040614736.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040614737_040664737.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040614737_040664737.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040614737_040664737.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040614737_040664737.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040664738_040714738.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040664738_040714738.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040664738_040714738.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040664738_040714738.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040714739_040764739.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040714739_040764739.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040714739_040764739.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040714739_040764739.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040764740_040814740.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040764740_040814740.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040764740_040814740.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040764740_040814740.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040814741_040864741.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040814741_040864741.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040814741_040864741.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040814741_040864741.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040864742_040914742.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040864742_040914742.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040864742_040914742.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040864742_040914742.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040914743_040964743.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040914743_040964743.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040914743_040964743.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040914743_040964743.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040964744_041014744.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040964744_041014744.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_040964744_041014744.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_040964744_041014744.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041014745_041064745.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041014745_041064745.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041014745_041064745.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041014745_041064745.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041064746_041114746.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041064746_041114746.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041064746_041114746.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041064746_041114746.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041114747_041164747.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041114747_041164747.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041114747_041164747.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041114747_041164747.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041164748_041214748.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041164748_041214748.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041164748_041214748.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041164748_041214748.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041214749_041264749.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041214749_041264749.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041214749_041264749.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041214749_041264749.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041264750_041314750.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041264750_041314750.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041264750_041314750.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041264750_041314750.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041314751_041364751.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041314751_041364751.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041314751_041364751.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041314751_041364751.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041364752_041414752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041364752_041414752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041364752_041414752.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041364752_041414752.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041414753_041464753.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041414753_041464753.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041414753_041464753.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041414753_041464753.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041464754_041514754.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041464754_041514754.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041464754_041514754.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041464754_041514754.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041514755_041564755.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041514755_041564755.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041514755_041564755.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041514755_041564755.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041564756_041614756.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041564756_041614756.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041564756_041614756.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041564756_041614756.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041614757_041664757.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041614757_041664757.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041614757_041664757.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041614757_041664757.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041664758_041714758.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041664758_041714758.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041664758_041714758.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041664758_041714758.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041714759_041764759.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041714759_041764759.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041714759_041764759.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041714759_041764759.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041764760_041814760.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041764760_041814760.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041764760_041814760.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041764760_041814760.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041814761_041864761.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041814761_041864761.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041814761_041864761.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041814761_041864761.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041864762_041914762.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041864762_041914762.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041864762_041914762.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041864762_041914762.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041914763_041964763.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041914763_041964763.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041914763_041964763.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041914763_041964763.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041964764_042014764.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041964764_042014764.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_041964764_042014764.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_041964764_042014764.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042014765_042064765.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042014765_042064765.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042014765_042064765.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042014765_042064765.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042064766_042114766.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042064766_042114766.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042064766_042114766.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042064766_042114766.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042114767_042164767.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042114767_042164767.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042114767_042164767.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042114767_042164767.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042164768_042214768.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042164768_042214768.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042164768_042214768.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042164768_042214768.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042214769_042264769.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042214769_042264769.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042214769_042264769.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042214769_042264769.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042264770_042314770.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042264770_042314770.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042264770_042314770.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042264770_042314770.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042314771_042364771.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042314771_042364771.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042314771_042364771.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042314771_042364771.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042364772_042414772.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042364772_042414772.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042364772_042414772.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042364772_042414772.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042414773_042464773.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042414773_042464773.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042414773_042464773.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042414773_042464773.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042464774_042514774.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042464774_042514774.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042464774_042514774.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042464774_042514774.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042514775_042564775.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042514775_042564775.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042514775_042564775.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042514775_042564775.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042564776_042614776.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042564776_042614776.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042564776_042614776.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042564776_042614776.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042614777_042664777.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042614777_042664777.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042614777_042664777.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042614777_042664777.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042664778_042714778.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042664778_042714778.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042664778_042714778.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042664778_042714778.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042714779_042764779.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042714779_042764779.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042714779_042764779.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042714779_042764779.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042764780_042814780.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042764780_042814780.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042764780_042814780.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042764780_042814780.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042814781_042864781.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042814781_042864781.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042814781_042864781.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042814781_042864781.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042864782_042914782.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042864782_042914782.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042864782_042914782.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042864782_042914782.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042914783_042964783.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042914783_042964783.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042914783_042964783.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042914783_042964783.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042964784_043014784.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042964784_043014784.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_042964784_043014784.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_042964784_043014784.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043014785_043064785.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043014785_043064785.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043014785_043064785.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043014785_043064785.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043064786_043114786.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043064786_043114786.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043064786_043114786.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043064786_043114786.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043114787_043164787.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043114787_043164787.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043114787_043164787.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043114787_043164787.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043164788_043214788.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043164788_043214788.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043164788_043214788.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043164788_043214788.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043214789_043264789.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043214789_043264789.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043214789_043264789.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043214789_043264789.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043264790_043314790.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043264790_043314790.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043264790_043314790.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043264790_043314790.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043314791_043364791.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043314791_043364791.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043314791_043364791.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043314791_043364791.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043364792_043414792.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043364792_043414792.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043364792_043414792.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043364792_043414792.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043414793_043464793.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043414793_043464793.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043414793_043464793.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043414793_043464793.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043464794_043514794.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043464794_043514794.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043464794_043514794.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043464794_043514794.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043514795_043564795.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043514795_043564795.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043514795_043564795.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043514795_043564795.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043564796_043614796.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043564796_043614796.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043564796_043614796.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043564796_043614796.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043614797_043664797.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043614797_043664797.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043614797_043664797.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043614797_043664797.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043664798_043714798.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043664798_043714798.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043664798_043714798.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043664798_043714798.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043714799_043764799.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043714799_043764799.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043714799_043764799.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043714799_043764799.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043764800_043814800.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043764800_043814800.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043764800_043814800.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043764800_043814800.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043814801_043864801.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043814801_043864801.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043814801_043864801.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043814801_043864801.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043864802_043914802.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043864802_043914802.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043864802_043914802.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043864802_043914802.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043914803_043964803.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043914803_043964803.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043914803_043964803.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043914803_043964803.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043964804_044014804.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043964804_044014804.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_043964804_044014804.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_043964804_044014804.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044014805_044064805.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044014805_044064805.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044014805_044064805.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044014805_044064805.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044064806_044114806.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044064806_044114806.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044064806_044114806.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044064806_044114806.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044114807_044164807.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044114807_044164807.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044114807_044164807.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044114807_044164807.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044164808_044214808.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044164808_044214808.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044164808_044214808.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044164808_044214808.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044214809_044264809.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044214809_044264809.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044214809_044264809.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044214809_044264809.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044264810_044314810.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044264810_044314810.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044264810_044314810.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044264810_044314810.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044314811_044364811.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044314811_044364811.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044314811_044364811.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044314811_044364811.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044364812_044414812.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044364812_044414812.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044364812_044414812.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044364812_044414812.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044414813_044464813.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044414813_044464813.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044414813_044464813.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044414813_044464813.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044464814_044514814.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044464814_044514814.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044464814_044514814.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044464814_044514814.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044514815_044564815.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044514815_044564815.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044514815_044564815.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044514815_044564815.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044564816_044614816.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044564816_044614816.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044564816_044614816.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044564816_044614816.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044614817_044664817.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044614817_044664817.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044614817_044664817.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044614817_044664817.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044664818_044714818.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044664818_044714818.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044664818_044714818.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044664818_044714818.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044714819_044764819.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044714819_044764819.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044714819_044764819.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044714819_044764819.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044764820_044814820.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044764820_044814820.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044764820_044814820.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044764820_044814820.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044814821_044864821.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044814821_044864821.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044814821_044864821.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044814821_044864821.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044864822_044914822.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044864822_044914822.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044864822_044914822.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044864822_044914822.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044914823_044964823.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044914823_044964823.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044914823_044964823.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044914823_044964823.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044964824_045014824.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044964824_045014824.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_044964824_045014824.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_044964824_045014824.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045014825_045064825.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045014825_045064825.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045014825_045064825.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045014825_045064825.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045064826_045114826.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045064826_045114826.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045064826_045114826.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045064826_045114826.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045114827_045164827.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045114827_045164827.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045114827_045164827.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045114827_045164827.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045164828_045214828.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045164828_045214828.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045164828_045214828.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045164828_045214828.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045214829_045264829.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045214829_045264829.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045214829_045264829.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045214829_045264829.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045264830_045314830.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045264830_045314830.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045264830_045314830.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045264830_045314830.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045314831_045364831.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045314831_045364831.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045314831_045364831.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045314831_045364831.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045364832_045414832.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045364832_045414832.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045364832_045414832.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045364832_045414832.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045414833_045464833.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045414833_045464833.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045414833_045464833.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045414833_045464833.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045464834_045514834.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045464834_045514834.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045464834_045514834.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045464834_045514834.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045514835_045564835.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045514835_045564835.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045514835_045564835.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045514835_045564835.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045564836_045614836.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045564836_045614836.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045564836_045614836.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045564836_045614836.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045614837_045664837.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045614837_045664837.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045614837_045664837.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045614837_045664837.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045664838_045714838.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045664838_045714838.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045664838_045714838.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045664838_045714838.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045714839_045764839.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045714839_045764839.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045714839_045764839.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045714839_045764839.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045764840_045814840.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045764840_045814840.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045764840_045814840.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045764840_045814840.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045814841_045864841.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045814841_045864841.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045814841_045864841.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045814841_045864841.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045864842_045914842.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045864842_045914842.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045864842_045914842.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045864842_045914842.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045914843_045964843.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045914843_045964843.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045914843_045964843.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045914843_045964843.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045964844_046014844.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045964844_046014844.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_045964844_046014844.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_045964844_046014844.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046014845_046064845.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046014845_046064845.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046014845_046064845.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046014845_046064845.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046064846_046114846.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046064846_046114846.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046064846_046114846.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046064846_046114846.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046114847_046164847.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046114847_046164847.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046114847_046164847.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046114847_046164847.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046164848_046214848.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046164848_046214848.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046164848_046214848.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046164848_046214848.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046214849_046264849.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046214849_046264849.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046214849_046264849.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046214849_046264849.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046264850_046314850.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046264850_046314850.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046264850_046314850.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046264850_046314850.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046314851_046364851.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046314851_046364851.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046314851_046364851.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046314851_046364851.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046364852_046414852.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046364852_046414852.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046364852_046414852.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046364852_046414852.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046414853_046464853.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046414853_046464853.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046414853_046464853.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046414853_046464853.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046464854_046514854.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046464854_046514854.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046464854_046514854.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046464854_046514854.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046514855_046564855.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046514855_046564855.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046514855_046564855.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046514855_046564855.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046564856_046614856.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046564856_046614856.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046564856_046614856.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046564856_046614856.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046614857_046664857.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046614857_046664857.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046614857_046664857.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046614857_046664857.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046664858_046714858.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046664858_046714858.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046664858_046714858.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046664858_046714858.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046714859_046764859.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046714859_046764859.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046714859_046764859.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046714859_046764859.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046764860_046814860.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046764860_046814860.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046764860_046814860.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046764860_046814860.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046814861_046864861.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046814861_046864861.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046814861_046864861.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046814861_046864861.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046864862_046914862.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046864862_046914862.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046864862_046914862.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046864862_046914862.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046914863_046964863.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046914863_046964863.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046914863_046964863.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046914863_046964863.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046964864_047014864.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046964864_047014864.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_046964864_047014864.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_046964864_047014864.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047014865_047064865.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047014865_047064865.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047014865_047064865.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047014865_047064865.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047064866_047114866.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047064866_047114866.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047064866_047114866.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047064866_047114866.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047114867_047164867.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047114867_047164867.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047114867_047164867.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047114867_047164867.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047164868_047214868.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047164868_047214868.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047164868_047214868.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047164868_047214868.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047214869_047264869.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047214869_047264869.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047214869_047264869.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047214869_047264869.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047264870_047314870.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047264870_047314870.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047264870_047314870.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047264870_047314870.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047314871_047364871.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047314871_047364871.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047314871_047364871.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047314871_047364871.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047364872_047414872.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047364872_047414872.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047364872_047414872.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047364872_047414872.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047414873_047464873.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047414873_047464873.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047414873_047464873.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047414873_047464873.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047464874_047514874.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047464874_047514874.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047464874_047514874.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047464874_047514874.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047514875_047564875.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047514875_047564875.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047514875_047564875.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047514875_047564875.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047564876_047614876.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047564876_047614876.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047564876_047614876.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047564876_047614876.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047614877_047664877.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047614877_047664877.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047614877_047664877.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047614877_047664877.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047664878_047714878.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047664878_047714878.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047664878_047714878.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047664878_047714878.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047714879_047764879.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047714879_047764879.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047714879_047764879.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047714879_047764879.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047764880_047814880.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047764880_047814880.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047764880_047814880.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047764880_047814880.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047814881_047864881.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047814881_047864881.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047814881_047864881.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047814881_047864881.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047864882_047914882.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047864882_047914882.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047864882_047914882.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047864882_047914882.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047914883_047964883.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047914883_047964883.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047914883_047964883.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047914883_047964883.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047964884_048014884.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047964884_048014884.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_047964884_048014884.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_047964884_048014884.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048014885_048064885.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048014885_048064885.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048014885_048064885.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048014885_048064885.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048064886_048114886.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048064886_048114886.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048064886_048114886.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048064886_048114886.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048114887_048164887.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048114887_048164887.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048114887_048164887.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048114887_048164887.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048164888_048214888.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048164888_048214888.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048164888_048214888.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048164888_048214888.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048214889_048264889.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048214889_048264889.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048214889_048264889.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048214889_048264889.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048264890_048314890.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048264890_048314890.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048264890_048314890.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048264890_048314890.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048314891_048364891.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048314891_048364891.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048314891_048364891.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048314891_048364891.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048364892_048414892.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048364892_048414892.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048364892_048414892.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048364892_048414892.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048414893_048464893.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048414893_048464893.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048414893_048464893.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048414893_048464893.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048464894_048514894.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048464894_048514894.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048464894_048514894.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048464894_048514894.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048514895_048564895.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048514895_048564895.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048514895_048564895.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048514895_048564895.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048564896_048614896.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048564896_048614896.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048564896_048614896.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048564896_048614896.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048614897_048664897.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048614897_048664897.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048614897_048664897.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048614897_048664897.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048664898_048714898.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048664898_048714898.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048664898_048714898.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048664898_048714898.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048714899_048764899.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048714899_048764899.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048714899_048764899.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048714899_048764899.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048764900_048814900.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048764900_048814900.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048764900_048814900.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048764900_048814900.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048814901_048864901.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048814901_048864901.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048814901_048864901.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048814901_048864901.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048864902_048914902.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048864902_048914902.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048864902_048914902.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048864902_048914902.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048914903_048964903.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048914903_048964903.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048914903_048964903.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048914903_048964903.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048964904_049014904.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048964904_049014904.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_048964904_049014904.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_048964904_049014904.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049014905_049064905.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049014905_049064905.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049014905_049064905.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049014905_049064905.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049064906_049114906.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049064906_049114906.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049064906_049114906.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049064906_049114906.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049114907_049164907.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049114907_049164907.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049114907_049164907.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049114907_049164907.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049164908_049214908.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049164908_049214908.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049164908_049214908.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049164908_049214908.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049214909_049264909.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049214909_049264909.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049214909_049264909.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049214909_049264909.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049264910_049314910.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049264910_049314910.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049264910_049314910.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049264910_049314910.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049314911_049364911.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049314911_049364911.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049314911_049364911.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049314911_049364911.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049364912_049414912.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049364912_049414912.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049364912_049414912.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049364912_049414912.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049414913_049464913.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049414913_049464913.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049414913_049464913.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049414913_049464913.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049464914_049514914.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049464914_049514914.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049464914_049514914.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049464914_049514914.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049514915_049564915.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049514915_049564915.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049514915_049564915.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049514915_049564915.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049564916_049614916.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049564916_049614916.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049564916_049614916.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049564916_049614916.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049614917_049664917.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049614917_049664917.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049614917_049664917.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049614917_049664917.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049664918_049714918.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049664918_049714918.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049664918_049714918.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049664918_049714918.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049714919_049764919.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049714919_049764919.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049714919_049764919.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049714919_049764919.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049764920_049814920.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049764920_049814920.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049764920_049814920.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049764920_049814920.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049814921_049864921.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049814921_049864921.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049814921_049864921.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049814921_049864921.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049864922_049914922.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049864922_049914922.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049864922_049914922.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049864922_049914922.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049914923_049964923.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049914923_049964923.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049914923_049964923.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049914923_049964923.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049964924_050014924.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049964924_050014924.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_049964924_050014924.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_049964924_050014924.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050014925_050064925.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050014925_050064925.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050014925_050064925.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050014925_050064925.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050064926_050114926.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050064926_050114926.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050064926_050114926.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050064926_050114926.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050114927_050164927.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050114927_050164927.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050114927_050164927.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050114927_050164927.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050164928_050214928.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050164928_050214928.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050164928_050214928.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050164928_050214928.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050214929_050264929.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050214929_050264929.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050214929_050264929.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050214929_050264929.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050264930_050314930.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050264930_050314930.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050264930_050314930.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050264930_050314930.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050314931_050364931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050314931_050364931.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050314931_050364931.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050314931_050364931.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050364932_050414932.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050364932_050414932.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050364932_050414932.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050364932_050414932.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050414933_050464933.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050414933_050464933.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050414933_050464933.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050414933_050464933.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050464934_050514934.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050464934_050514934.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050464934_050514934.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050464934_050514934.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050514935_050564935.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050514935_050564935.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050514935_050564935.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050514935_050564935.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050564936_050614936.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050564936_050614936.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050564936_050614936.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050564936_050614936.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050614937_050664937.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050614937_050664937.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050614937_050664937.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050614937_050664937.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050664938_050714938.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050664938_050714938.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050664938_050714938.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050664938_050714938.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050714939_050764939.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050714939_050764939.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050714939_050764939.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050714939_050764939.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050764940_050814940.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050764940_050814940.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050764940_050814940.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050764940_050814940.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050814941_050864941.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050814941_050864941.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050814941_050864941.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050814941_050864941.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050864942_050914942.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050864942_050914942.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050864942_050914942.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050864942_050914942.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050914943_050964943.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050914943_050964943.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050914943_050964943.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050914943_050964943.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050964944_051014944.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050964944_051014944.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_050964944_051014944.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_050964944_051014944.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051014945_051064945.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051014945_051064945.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051014945_051064945.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051014945_051064945.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051064946_051114946.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051064946_051114946.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051064946_051114946.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051064946_051114946.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051114947_051164947.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051114947_051164947.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051114947_051164947.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051114947_051164947.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051164948_051214948.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051164948_051214948.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051164948_051214948.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051164948_051214948.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051214949_051264949.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051214949_051264949.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051214949_051264949.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051214949_051264949.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051264950_051314950.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051264950_051314950.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051264950_051314950.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051264950_051314950.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051314951_051364951.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051314951_051364951.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051314951_051364951.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051314951_051364951.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051364952_051414952.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051364952_051414952.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051364952_051414952.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051364952_051414952.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051414953_051464953.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051414953_051464953.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051414953_051464953.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051414953_051464953.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051464954_051514954.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051464954_051514954.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051464954_051514954.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051464954_051514954.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051514955_051564955.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051514955_051564955.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051514955_051564955.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051514955_051564955.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051564956_051614956.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051564956_051614956.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051564956_051614956.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051564956_051614956.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051614957_051664957.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051614957_051664957.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051614957_051664957.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051614957_051664957.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051664958_051714958.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051664958_051714958.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051664958_051714958.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051664958_051714958.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051714959_051764959.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051714959_051764959.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051714959_051764959.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051714959_051764959.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051764960_051814960.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051764960_051814960.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051764960_051814960.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051764960_051814960.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051814961_051864961.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051814961_051864961.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051814961_051864961.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051814961_051864961.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051864962_051914962.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051864962_051914962.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051864962_051914962.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051864962_051914962.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051914963_051964963.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051914963_051964963.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051914963_051964963.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051914963_051964963.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051964964_052014964.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051964964_052014964.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_051964964_052014964.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_051964964_052014964.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052014965_052064965.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052014965_052064965.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052014965_052064965.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052014965_052064965.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052064966_052114966.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052064966_052114966.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052064966_052114966.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052064966_052114966.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052114967_052164967.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052114967_052164967.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052114967_052164967.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052114967_052164967.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052164968_052214968.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052164968_052214968.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052164968_052214968.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052164968_052214968.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052214969_052264969.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052214969_052264969.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052214969_052264969.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052214969_052264969.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052264970_052314970.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052264970_052314970.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052264970_052314970.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052264970_052314970.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052314971_052364971.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052314971_052364971.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052314971_052364971.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052314971_052364971.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052364972_052414972.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052364972_052414972.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052364972_052414972.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052364972_052414972.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052414973_052464973.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052414973_052464973.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052414973_052464973.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052414973_052464973.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052464974_052514974.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052464974_052514974.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052464974_052514974.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052464974_052514974.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052514975_052564975.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052514975_052564975.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052514975_052564975.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052514975_052564975.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052564976_052614976.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052564976_052614976.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052564976_052614976.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052564976_052614976.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052614977_052664977.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052614977_052664977.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052614977_052664977.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052614977_052664977.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052664978_052714978.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052664978_052714978.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052664978_052714978.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052664978_052714978.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052714979_052764979.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052714979_052764979.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052714979_052764979.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052714979_052764979.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052764980_052814980.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052764980_052814980.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052764980_052814980.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052764980_052814980.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052814981_052864981.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052814981_052864981.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052814981_052864981.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052814981_052864981.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052864982_052914982.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052864982_052914982.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052864982_052914982.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052864982_052914982.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052914983_052964983.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052914983_052964983.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052914983_052964983.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052914983_052964983.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052964984_053000000.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052964984_053000000.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/streamline__decode_logs_history_052964984_053000000.sql
+++ b/models/silver/streamline/decoder/history/streamline__decode_logs_history_052964984_053000000.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = "view",
-    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+    materialized = "view"
 ) }}
 
 {% set start = this.identifier.split("_") [-2] %}


### PR DESCRIPTION
- builds history files for decoding polygon logs in blocks 18m through 53m (and necessary macros)
- modifies workflows for changes