### PR TITLE
An 2854/core nft tables

### DIFF
--- a/models/gold/core__ez_nft_mints.sql
+++ b/models/gold/core__ez_nft_mints.sql
@@ -1,0 +1,26 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true },
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
+) }}
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address AS nft_address,
+    NAME AS project_name,
+    from_address AS nft_from_address,
+    to_address AS nft_to_address,
+    tokenId,
+    erc1155_value,
+    event_index
+FROM
+    {{ ref('silver__nft_transfers') }} A
+    JOIN {{ ref('core__dim_contracts') }}
+    b
+    ON A.contract_address = b.address
+WHERE
+    event_type = 'mint'
+    AND from_address = '0x0000000000000000000000000000000000000000'

--- a/models/gold/core__ez_nft_mints.yml
+++ b/models/gold/core__ez_nft_mints.yml
@@ -1,0 +1,26 @@
+version: 2
+models:
+  - name: core__ez_nft_mints
+    description: 'This table contains all ERC721 and ERC1155 mint events.'
+      
+    columns:
+      - name: BLOCK_NUMBER
+        description: 'The block number of the NFT transfer.'
+      - name: BLOCK_TIMESTAMP
+        description: 'The block timestamp of the NFT transfer.'
+      - name: TX_HASH
+        description: 'The transaction hash of the NFT transfer. Please note this is not unique, as it is possible to have multiple NFT transfers in a single transaction.'
+      - name: NFT_ADDRESS
+        description: 'The address of the NFT contract.'
+      - name: PROJECT_NAME
+        description: 'The name of the project, read from the NFT contract.'
+      - name: ERC1155_VALUE
+        description: 'The value of the ERC1155 transfer. This is only populated for ERC1155 transfers.'
+      - name: NFT_FROM_ADDRESS
+        description: 'The address of the sender of the NFT transfer.'
+      - name: NFT_TO_ADDRESS
+        description: 'The address of the recipient of the NFT transfer.'
+      - name: TOKENID
+        description: 'The token ID of the NFT transfer.'      
+      - name: EVENT_INDEX
+        description: 'The index of the NFT transfer within the transaction. This is used to ensure that multiple NFT transfers in a single transaction are not duplicated.'

--- a/models/gold/core__ez_nft_transfers.sql
+++ b/models/gold/core__ez_nft_transfers.sql
@@ -1,0 +1,24 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true },
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
+) }}
+
+SELECT
+    block_timestamp,
+    block_number,
+    tx_hash,
+    event_index,
+    event_type,
+    contract_address AS nft_address,
+    NAME AS project_name,
+    from_address AS nft_from_address,
+    to_address AS nft_to_address,
+    tokenId,
+    erc1155_value
+FROM
+    {{ ref('silver__nft_transfers') }} A
+    LEFT JOIN {{ ref('core__dim_contracts') }}
+    b
+    ON A.contract_address = b.address

--- a/models/gold/core__ez_nft_transfers.yml
+++ b/models/gold/core__ez_nft_transfers.yml
@@ -1,0 +1,28 @@
+version: 2
+models:
+  - name: core__ez_nft_transfers
+    description: 'This table contains all ERC721 transfer and ERC1155 transfer single events.'
+      
+    columns:
+      - name: BLOCK_NUMBER
+        description: 'The block number of the NFT transfer.'
+      - name: BLOCK_TIMESTAMP
+        description: 'The block timestamp of the NFT transfer.'
+      - name: TX_HASH
+        description: 'The transaction hash of the NFT transfer. Please note this is not unique, as it is possible to have multiple NFT transfers in a single transaction.'
+      - name: EVENT_TYPE
+        description: 'The type of NFT transfer. This can be either "mint" or "other".'
+      - name: NFT_ADDRESS
+        description: 'The address of the NFT contract.'
+      - name: PROJECT_NAME
+        description: 'The name of the project, read from the NFT contract.'
+      - name: ERC1155_VALUE
+        description: 'The value of the ERC1155 transfer. This is only populated for ERC1155 transfers.'
+      - name: NFT_FROM_ADDRESS
+        description: 'The address of the sender of the NFT transfer.'
+      - name: NFT_TO_ADDRESS
+        description: 'The address of the recipient of the NFT transfer.'
+      - name: TOKENID
+        description: 'The token ID of the NFT transfer.'      
+      - name: EVENT_INDEX
+        description: 'The index of the NFT transfer within the transaction. This is used to ensure that multiple NFT transfers in a single transaction are not duplicated.'

--- a/models/silver/silver__nft_transfers.sql
+++ b/models/silver/silver__nft_transfers.sql
@@ -1,0 +1,279 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
+    merge_update_columns = ["_log_id"],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)"
+) }}
+
+WITH base AS (
+
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        event_index,
+        contract_address,
+        event_name,
+        topics,
+        event_inputs,
+        DATA,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        tx_status = 'SUCCESS'
+        AND (
+            (
+                topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+                AND DATA = '0x'
+                AND topics [3] IS NOT NULL
+            ) --erc721s
+            OR (
+                topics [0] :: STRING = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+            ) --erc1155s
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        )
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+erc721s AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address,
+        PUBLIC.udf_hex_to_int(
+            topics [3] :: STRING
+        ) AS token_id,
+        NULL AS erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+        AND DATA = '0x'
+        AND topics [3] IS NOT NULL
+        AND contract_address NOT IN (
+            '0x6ba6f2207e343923ba692e5cae646fb0f566db8d',
+            '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb'
+        )
+),
+transfer_singles AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS operator_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS to_address,
+        PUBLIC.udf_hex_to_int(
+            segmented_data [0] :: STRING
+        ) AS token_id,
+        PUBLIC.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) AS erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+),
+punks_bought AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        PUBLIC.udf_hex_to_int(
+            topics [1] :: STRING
+        ) AS token_id,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS to_address,
+        NULL AS erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3'
+),
+punks_transfer AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        PUBLIC.udf_hex_to_int(
+            DATA :: STRING
+        ) AS token_id,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address,
+        NULL AS erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0x05af636b70da6819000c49f85b21fa82081c632069bb626f30932034099107d8'
+),
+regular_punk_transfers AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address,
+        _inserted_timestamp,
+        event_index
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+        AND contract_address IN (
+            '0x6ba6f2207e343923ba692e5cae646fb0f566db8d',
+            '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb'
+        )
+),
+legacy_tokens AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        CONCAT('0x', SUBSTR(segmented_data [0], 25, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(segmented_data [1], 25, 40)) AS to_address,
+        PUBLIC.udf_hex_to_int(
+            segmented_data [2] :: STRING
+        ) AS token_id,
+        NULL AS erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        base
+    WHERE
+        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+        AND topics [1] IS NULL
+),
+all_transfers AS (
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        from_address,
+        to_address,
+        token_id,
+        erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        erc721s
+    UNION ALL
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        from_address,
+        to_address,
+        token_id,
+        erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        transfer_singles
+    UNION ALL
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        from_address,
+        to_address,
+        token_id,
+        erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        punks_bought
+    UNION ALL
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        from_address,
+        to_address,
+        token_id,
+        erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        punks_transfer
+    UNION ALL
+    SELECT
+        _log_id,
+        block_number,
+        tx_hash,
+        block_timestamp,
+        contract_address,
+        from_address,
+        to_address,
+        token_id,
+        erc1155_value,
+        _inserted_timestamp,
+        event_index
+    FROM
+        legacy_tokens
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    contract_address,
+    from_address,
+    to_address,
+    token_id AS tokenid,
+    erc1155_value,
+    CASE
+        WHEN from_address = '0x0000000000000000000000000000000000000000' THEN 'mint'
+        ELSE 'other'
+    END AS event_type,
+    _log_id,
+    _inserted_timestamp
+FROM
+    all_transfers
+WHERE
+    to_address IS NOT NULL qualify ROW_NUMBER() over (
+        PARTITION BY _log_id
+        ORDER BY
+            _inserted_timestamp DESC
+    ) = 1

--- a/models/silver/silver__nft_transfers.sql
+++ b/models/silver/silver__nft_transfers.sql
@@ -96,87 +96,6 @@ transfer_singles AS (
     WHERE
         topics [0] :: STRING = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
 ),
-punks_bought AS (
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        PUBLIC.udf_hex_to_int(
-            topics [1] :: STRING
-        ) AS token_id,
-        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS from_address,
-        CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS to_address,
-        NULL AS erc1155_value,
-        _inserted_timestamp,
-        event_index
-    FROM
-        base
-    WHERE
-        topics [0] :: STRING = '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3'
-),
-punks_transfer AS (
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        PUBLIC.udf_hex_to_int(
-            DATA :: STRING
-        ) AS token_id,
-        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
-        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address,
-        NULL AS erc1155_value,
-        _inserted_timestamp,
-        event_index
-    FROM
-        base
-    WHERE
-        topics [0] :: STRING = '0x05af636b70da6819000c49f85b21fa82081c632069bb626f30932034099107d8'
-),
-regular_punk_transfers AS (
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
-        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address,
-        _inserted_timestamp,
-        event_index
-    FROM
-        base
-    WHERE
-        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
-        AND contract_address IN (
-            '0x6ba6f2207e343923ba692e5cae646fb0f566db8d',
-            '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb'
-        )
-),
-legacy_tokens AS (
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        CONCAT('0x', SUBSTR(segmented_data [0], 25, 40)) AS from_address,
-        CONCAT('0x', SUBSTR(segmented_data [1], 25, 40)) AS to_address,
-        PUBLIC.udf_hex_to_int(
-            segmented_data [2] :: STRING
-        ) AS token_id,
-        NULL AS erc1155_value,
-        _inserted_timestamp,
-        event_index
-    FROM
-        base
-    WHERE
-        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
-        AND topics [1] IS NULL
-),
 all_transfers AS (
     SELECT
         _log_id,
@@ -207,51 +126,6 @@ all_transfers AS (
         event_index
     FROM
         transfer_singles
-    UNION ALL
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        from_address,
-        to_address,
-        token_id,
-        erc1155_value,
-        _inserted_timestamp,
-        event_index
-    FROM
-        punks_bought
-    UNION ALL
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        from_address,
-        to_address,
-        token_id,
-        erc1155_value,
-        _inserted_timestamp,
-        event_index
-    FROM
-        punks_transfer
-    UNION ALL
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        contract_address,
-        from_address,
-        to_address,
-        token_id,
-        erc1155_value,
-        _inserted_timestamp,
-        event_index
-    FROM
-        legacy_tokens
 )
 SELECT
     block_number,

--- a/models/silver/silver__nft_transfers.yml
+++ b/models/silver/silver__nft_transfers.yml
@@ -1,0 +1,60 @@
+
+version: 2
+models:
+  - name: silver__nft_transfers
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null    
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT      
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ    
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: FROM_ADDRESS
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKENID
+        tests:
+          - not_null
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ 

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -1,0 +1,26 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+SELECT
+    HOUR,
+    token_address AS eth_address,
+    CASE
+        WHEN token_address = LOWER('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2') THEN LOWER('0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619')
+        WHEN token_address = LOWER('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48') THEN LOWER('0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174')
+        WHEN token_address = LOWER('0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0') THEN LOWER('0x0000000000000000000000000000000000001010')
+    END AS matic_address,
+    price
+FROM
+    {{ source(
+        'ethereum',
+        'fact_hourly_token_prices'
+    ) }}
+WHERE
+    token_address IN (
+        LOWER('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'),
+        --WETH
+        LOWER('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
+        --USDC
+        LOWER('0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0') -- MATIC
+    )

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -1,64 +1,11 @@
 {{ config(
     materialized = 'incremental',
     unique_key = '_log_id',
-    cluster_by = ['_inserted_timestamp::DATE']
+    cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE']
 ) }}
 
 WITH logs AS (
 
-    SELECT
-        _log_id,
-        block_number,
-        block_timestamp,
-        tx_hash,
-        origin_function_signature,
-        origin_from_address,
-        origin_to_address,
-        contract_address,
-        event_name,
-        event_index,
-        event_inputs,
-        topics,
-        DATA,
-        _inserted_timestamp :: TIMESTAMP AS _inserted_timestamp
-    FROM
-        {{ ref('silver__logs') }}
-    WHERE
-        tx_status = 'SUCCESS'
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(
-            _inserted_timestamp
-        )
-    FROM
-        {{ this }}
-)
-{% endif %}
-),
-transfers AS (
-    SELECT
-        _log_id,
-        block_number,
-        tx_hash,
-        block_timestamp,
-        origin_function_signature,
-        origin_from_address,
-        origin_to_address,
-        contract_address :: STRING AS contract_address,
-        event_inputs :from :: STRING AS from_address,
-        event_inputs :to :: STRING AS to_address,
-        event_inputs :value :: FLOAT AS raw_amount,
-        event_index,
-        _inserted_timestamp
-    FROM
-        logs
-    WHERE
-        event_name = 'Transfer'
-        AND raw_amount IS NOT NULL
-),
-find_missing_events AS (
     SELECT
         _log_id,
         block_number,
@@ -70,55 +17,25 @@ find_missing_events AS (
         contract_address :: STRING AS contract_address,
         CONCAT('0x', SUBSTR(topics [1], 27, 40)) :: STRING AS from_address,
         CONCAT('0x', SUBSTR(topics [2], 27, 40)) :: STRING AS to_address,
-        COALESCE(udf_hex_to_int(topics [3] :: STRING), udf_hex_to_int(SUBSTR(DATA, 3, 64))) :: FLOAT AS raw_amount,
+        ethereum.public.udf_hex_to_int(SUBSTR(DATA, 3, 64)) :: FLOAT AS raw_amount,
         event_index,
         _inserted_timestamp
     FROM
-        logs
+        {{ ref('silver__logs') }}
     WHERE
-        event_name IS NULL
-        AND contract_address IN (
-            SELECT
-                DISTINCT contract_address
-            FROM
-                transfers
+        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
         )
-        AND topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
-),
-all_transfers AS (
-    SELECT
-        _log_id,
-        tx_hash,
-        block_number,
-        block_timestamp,
-        origin_function_signature,
-        origin_from_address,
-        origin_to_address,
-        contract_address,
-        from_address,
-        to_address,
-        raw_amount,
-        event_index,
-        _inserted_timestamp
     FROM
-        transfers
-    UNION ALL
-    SELECT
-        _log_id,
-        tx_hash,
-        block_number,
-        block_timestamp,
-        origin_function_signature,
-        origin_from_address,
-        origin_to_address,
-        contract_address,
-        from_address,
-        to_address,
-        raw_amount,
-        event_index,
-        _inserted_timestamp
-    FROM
-        find_missing_events
+        {{ this }}
+)
+{% endif %}
 )
 SELECT
     _log_id,
@@ -135,7 +52,10 @@ SELECT
     _inserted_timestamp,
     event_index
 FROM
-    all_transfers qualify(ROW_NUMBER() over(PARTITION BY _log_id
+    logs
+WHERE
+    raw_amount IS NOT NULL
+    AND to_address IS NOT NULL
+    AND from_address IS NOT NULL qualify(ROW_NUMBER() over(PARTITION BY _log_id
 ORDER BY
     _inserted_timestamp DESC)) = 1
-     


### PR DESCRIPTION
- creates core NFT transfer models (`ez_nft_transfers` & `ez_nft_mints` + docs and tests
- rebuilds token transfers without `event_name` / `event_inputs` 