### PR TITLE
AN-2915/read-names-str

### DIFF
--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -18,6 +18,10 @@
 
         {% endset %}
         {% do run_query(sql) %}
+        {% set name %}
+        {{- reference_models.create_udfs() -}}
+        {% endset %}
+        {% do run_query(sql) %}
         {% if target.database != "POLYGON_COMMUNITY_DEV" %}
             {% set sql %}
             {{ create_udf_get_chainhead() }}

--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -19,7 +19,7 @@
         {% endset %}
         {% do run_query(sql) %}
         {% set name %}
-        {{- reference_models.create_udfs() -}}
+        {{- fsc_utils.create_udfs() -}}
         {% endset %}
         {% do run_query(sql) %}
         {% if target.database != "POLYGON_COMMUNITY_DEV" %}

--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -9,13 +9,6 @@
         {{ create_udtf_get_base_table(
             schema = "streamline"
         ) }}
-        {{ create_udf_keccak(
-            schema = 'silver'
-        ) }}
-          {{ create_udf_simple_event_names(
-            schema = 'silver'
-        ) }}
-
         {% endset %}
         {% do run_query(sql) %}
         {% set name %}

--- a/models/silver/silver__contracts.sql
+++ b/models/silver/silver__contracts.sql
@@ -34,7 +34,7 @@ token_names AS (
         block_number,
         function_signature,
         read_output,
-        reference.utils.udf_hex_to_string(
+        utils.udf_hex_to_string(
             SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_name
     FROM
         base_metadata
@@ -48,7 +48,7 @@ token_symbols AS (
         block_number,
         function_signature,
         read_output,
-        reference.utils.udf_hex_to_string(
+        utils.udf_hex_to_string(
             SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_symbol
     FROM
         base_metadata

--- a/models/silver/silver__contracts.sql
+++ b/models/silver/silver__contracts.sql
@@ -59,7 +59,7 @@ token_symbols AS (
 token_decimals AS (
     SELECT
         contract_address,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             read_output :: STRING
         ) AS token_decimals,
         LENGTH(token_decimals) AS dec_length

--- a/models/silver/silver__contracts.sql
+++ b/models/silver/silver__contracts.sql
@@ -34,35 +34,13 @@ token_names AS (
         block_number,
         function_signature,
         read_output,
-        regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
-        TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
-                segmented_output [1] :: STRING
-            )
-        ) AS sub_len,
-        TRY_HEX_DECODE_STRING(
-            SUBSTR(
-                segmented_output [2] :: STRING,
-                0,
-                sub_len * 2
-            )
-        ) AS name1,
-        TRY_HEX_DECODE_STRING(RTRIM(segmented_output [2] :: STRING, 0)) AS name2,
-        TRY_HEX_DECODE_STRING(RTRIM(segmented_output [0] :: STRING, 0)) AS name3,
-        TRY_HEX_DECODE_STRING(
-            CONCAT(RTRIM(segmented_output [0] :: STRING, 0), '0')
-        ) AS name4,
-        COALESCE(
-            name1,
-            name2,
-            name3,
-            name4
-        ) AS token_name
+        reference.utils.udf_hex_to_string(
+            SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_name
     FROM
         base_metadata
     WHERE
         function_signature = '0x06fdde03'
-        AND segmented_output [1] :: STRING IS NOT NULL
+        AND token_name IS NOT NULL
 ),
 token_symbols AS (
     SELECT
@@ -70,35 +48,13 @@ token_symbols AS (
         block_number,
         function_signature,
         read_output,
-        regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
-        TRY_TO_NUMBER(
-            PUBLIC.udf_hex_to_int(
-                segmented_output [1] :: STRING
-            )
-        ) AS sub_len,
-        TRY_HEX_DECODE_STRING(
-            SUBSTR(
-                segmented_output [2] :: STRING,
-                0,
-                sub_len * 2
-            )
-        ) AS symbol1,
-        TRY_HEX_DECODE_STRING(RTRIM(segmented_output [2] :: STRING, 0)) AS symbol2,
-        TRY_HEX_DECODE_STRING(RTRIM(segmented_output [0] :: STRING, 0)) AS symbol3,
-        TRY_HEX_DECODE_STRING(
-            CONCAT(RTRIM(segmented_output [0] :: STRING, 0), '0')
-        ) AS symbol4,
-        COALESCE(
-            symbol1,
-            symbol2,
-            symbol3,
-            symbol4
-        ) AS token_symbol
+        reference.utils.udf_hex_to_string(
+            SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_symbol
     FROM
         base_metadata
     WHERE
         function_signature = '0x95d89b41'
-        AND segmented_output [1] :: STRING IS NOT NULL
+        AND token_symbol IS NOT NULL
 ),
 token_decimals AS (
     SELECT

--- a/packages.yml
+++ b/packages.yml
@@ -6,4 +6,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: main
+    revision: v1.1.0

--- a/packages.yml
+++ b/packages.yml
@@ -5,3 +5,5 @@ packages:
     version: 0.8.2
   - package: dbt-labs/dbt_utils
     version: 1.0.0
+  - git: https://github.com/FlipsideCrypto/reference-models.git
+    revision: delete-files

--- a/packages.yml
+++ b/packages.yml
@@ -5,5 +5,5 @@ packages:
     version: 0.8.2
   - package: dbt-labs/dbt_utils
     version: 1.0.0
-  - git: "https://github.com/FlipsideCrypto/fsc-utils.git"
-    revision: "main"
+  - git: https://github.com/FlipsideCrypto/fsc-utils.git
+    revision: main

--- a/packages.yml
+++ b/packages.yml
@@ -5,5 +5,5 @@ packages:
     version: 0.8.2
   - package: dbt-labs/dbt_utils
     version: 1.0.0
-  - git: https://github.com/FlipsideCrypto/reference-models.git
-    revision: delete-files
+  - git: "https://github.com/FlipsideCrypto/fsc-utils.git"
+    revision: "main"


### PR DESCRIPTION
1. Adds fsc-utils dbt package
2. New udf for transforming hex to string, resolving issue with contract names and symbols
3. Requires grants to `dbt_cloud_polygon` for new `utils` schema
4. Requires `dbt run-operation create_udfs --var '{"UPDATE_UDFS_AND_SPS":True}'`
5. Requires `dbt run -m models/silver/silver__contracts.sql+ --full-refresh`