### PR TITLE
standardise nft tables for polygon 

### DIFF
--- a/models/doc_descriptions/nft/nft_aggregator_name.md
+++ b/models/doc_descriptions/nft/nft_aggregator_name.md
@@ -1,0 +1,5 @@
+{% docs nft_aggregator_name%}
+
+The name of the aggregator platform where the sale took place. If the sale did not take place via an aggregator platform, then the value will be null.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_block_no.md
+++ b/models/doc_descriptions/nft/nft_block_no.md
@@ -1,0 +1,5 @@
+{% docs nft_block_no %}
+
+The block number at which the NFT event occurred.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_blocktime.md
+++ b/models/doc_descriptions/nft/nft_blocktime.md
@@ -1,0 +1,5 @@
+{% docs nft_blocktime %}
+
+The block timestamp at which the NFT event occurred.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_buyer_address.md
+++ b/models/doc_descriptions/nft/nft_buyer_address.md
@@ -1,0 +1,5 @@
+{% docs nft_buyer_address %}
+
+The address of the buyer of the NFT in the transaction. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_creator_fee.md
+++ b/models/doc_descriptions/nft/nft_creator_fee.md
@@ -1,0 +1,5 @@
+{% docs nft_creator_fee %}
+
+The decimal adjusted amount of fees paid to the NFT collection as royalty payments for this NFT event in the transaction's currency. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_creator_fee_usd.md
+++ b/models/doc_descriptions/nft/nft_creator_fee_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_creator_fee_usd %}
+
+The amount of fees paid to the NFT collection as royalty payments for this NFT event in US dollars. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_currency_address.md
+++ b/models/doc_descriptions/nft/nft_currency_address.md
@@ -1,0 +1,5 @@
+{% docs nft_currency_address %}
+
+The token contract address for this NFT event. This will be `MATIC` for native MATIC transactions. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_currency_symbol.md
+++ b/models/doc_descriptions/nft/nft_currency_symbol.md
@@ -1,0 +1,5 @@
+{% docs nft_currency_symbol %}
+
+The token symbol for this NFT event. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_erc1155_value.md
+++ b/models/doc_descriptions/nft/nft_erc1155_value.md
@@ -1,0 +1,5 @@
+{% docs nft_erc1155_value %}
+
+If the NFT is an ERC-1155 contract, this field may be one or greater, representing the number of tokens. If it is not an ERC-1155 token, this value will be null.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_event_index.md
+++ b/models/doc_descriptions/nft/nft_event_index.md
@@ -1,0 +1,5 @@
+{% docs nft_event_index %}
+
+The event number within a transaction 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_event_type.md
+++ b/models/doc_descriptions/nft/nft_event_type.md
@@ -1,0 +1,5 @@
+{% docs nft_event_type %}
+
+The type of NFT event in this transaction, either `sale`,  `bid_won` or `redeem`. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_events_table_doc.md
+++ b/models/doc_descriptions/nft/nft_events_table_doc.md
@@ -1,0 +1,5 @@
+{% docs nft_events_table_doc %}
+
+This table contains NFT sales on the Ethereum blockchain. More NFT marketplaces will be added over time. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_from_address.md
+++ b/models/doc_descriptions/nft/nft_from_address.md
@@ -1,0 +1,5 @@
+{% docs nft_from_address %}
+
+The sending address of the NFT in the transaction. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_metadata.md
+++ b/models/doc_descriptions/nft/nft_metadata.md
@@ -1,0 +1,5 @@
+{% docs nft_metadata %}
+
+The token metadata for this NFT. This may be blank for many NFTs. We are working to expand this field. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mint_count.md
+++ b/models/doc_descriptions/nft/nft_mint_count.md
@@ -1,0 +1,5 @@
+{% docs nft_mint_count %}
+
+The number of NFTs minted in this event.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mint_doc.md
+++ b/models/doc_descriptions/nft/nft_mint_doc.md
@@ -1,0 +1,5 @@
+{% docs nft_mint_doc %}
+
+This table contains NFT mint events, defined as an NFT transfers from a burn address to an address, on the Polygon blockchain.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mint_price.md
+++ b/models/doc_descriptions/nft/nft_mint_price.md
@@ -1,0 +1,5 @@
+{% docs nft_mint_price %}
+
+The price paid in MATIC to mint the NFT(s).
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mint_price_usd.md
+++ b/models/doc_descriptions/nft/nft_mint_price_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_mint_price_usd %}
+
+The price paid in US dollars to mint the NFT(s).
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mints_symbol.md
+++ b/models/doc_descriptions/nft/nft_mints_symbol.md
@@ -1,0 +1,5 @@
+{% docs nft_mints_symbol %}
+
+The symbol of the token supplied to mint the NFT, if applicable. This field may not handle all edge cases.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mints_token_address.md
+++ b/models/doc_descriptions/nft/nft_mints_token_address.md
@@ -1,0 +1,5 @@
+{% docs nft_mints_token_address %}
+
+The contract address of the token supplied to mint the NFT, if applicable. This field may not handle all edge cases.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mints_token_price.md
+++ b/models/doc_descriptions/nft/nft_mints_token_price.md
@@ -1,0 +1,5 @@
+{% docs nft_mints_token_price %}
+
+The decimal adjusted amount of tokens supplied within the same transaction to mint the NFT. This field may not handle all edge cases.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_mints_token_price_usd.md
+++ b/models/doc_descriptions/nft/nft_mints_token_price_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_mints_token_price_usd %}
+
+The amount of tokens supplied in US dollars within the same transaction to mint the NFT. This field may not handle all edge cases.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_nft_address.md
+++ b/models/doc_descriptions/nft/nft_nft_address.md
@@ -1,0 +1,5 @@
+{% docs nft_nft_address %}
+
+The contract address of the NFT.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_origin_from.md
+++ b/models/doc_descriptions/nft/nft_origin_from.md
@@ -1,0 +1,5 @@
+{% docs nft_origin_from %}
+
+The from address of this transaction. In most cases, this is the NFT buyer. However, for some more complex transactions, it may not be the NFT buyer.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_origin_sig.md
+++ b/models/doc_descriptions/nft/nft_origin_sig.md
@@ -1,0 +1,5 @@
+{% docs nft_origin_sig %}
+
+The function signature of this transaction.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_origin_to.md
+++ b/models/doc_descriptions/nft/nft_origin_to.md
@@ -1,0 +1,5 @@
+{% docs nft_origin_to %}
+
+The to address of this transaction. In most cases, this is the exchange contract. However, for some more complex NFT events, such as aggregate buys with tools such as Gem and Genie, this may not be the exchange address. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_platform_address.md
+++ b/models/doc_descriptions/nft/nft_platform_address.md
@@ -1,0 +1,5 @@
+{% docs nft_platform_address %}
+
+The address of the exchange used for the transaction.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_platform_exchange_version.md
+++ b/models/doc_descriptions/nft/nft_platform_exchange_version.md
@@ -1,0 +1,5 @@
+{% docs nft_platform_exchange_version %}
+
+The version of the exchange contract used for the transaction.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_platform_fee.md
+++ b/models/doc_descriptions/nft/nft_platform_fee.md
@@ -1,0 +1,5 @@
+{% docs nft_platform_fee %}
+
+The decimal adjusted amount of fees paid to the platform for this NFT event in the transaction's currency. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_platform_fee_usd.md
+++ b/models/doc_descriptions/nft/nft_platform_fee_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_platform_fee_usd %}
+
+The amount of fees paid to the platform for this NFT event in US dollars. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_platform_name.md
+++ b/models/doc_descriptions/nft/nft_platform_name.md
@@ -1,0 +1,5 @@
+{% docs nft_platform_name %}
+
+The name of the exchange used for the trade. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_price.md
+++ b/models/doc_descriptions/nft/nft_price.md
@@ -1,0 +1,5 @@
+{% docs nft_price %}
+
+The amount of the NFT event in the currency in which the transaction occurred, decimal adjusted where possible. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_price_usd.md
+++ b/models/doc_descriptions/nft/nft_price_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_price_usd %}
+
+The amount of the NFT event in US dollars. This will be 0 for tokens without a decimal adjustment or hourly price.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_project_name.md
+++ b/models/doc_descriptions/nft/nft_project_name.md
@@ -1,0 +1,5 @@
+{% docs nft_project_name %}
+
+The name of the NFT project. This field, along with metadata, will be filled in over time.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_seller_address.md
+++ b/models/doc_descriptions/nft/nft_seller_address.md
@@ -1,0 +1,5 @@
+{% docs nft_seller_address %}
+
+The address of the seller of the NFT in the transaction. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_to_address.md
+++ b/models/doc_descriptions/nft/nft_to_address.md
@@ -1,0 +1,5 @@
+{% docs nft_to_address %}
+
+The receiving address of the NFT in the transaction. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_tokenid.md
+++ b/models/doc_descriptions/nft/nft_tokenid.md
@@ -1,0 +1,5 @@
+{% docs nft_tokenid %}
+
+The token ID for this NFT contract. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_total_fees.md
+++ b/models/doc_descriptions/nft/nft_total_fees.md
@@ -1,0 +1,5 @@
+{% docs nft_total_fees %}
+
+The total amount of fees paid relating to the NFT purchase in the transaction currency. This includes royalty payments to creators and platform fees. Please note, this does not include the gas fee.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_total_fees_usd.md
+++ b/models/doc_descriptions/nft/nft_total_fees_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_total_fees_usd %}
+
+The total amount of fees paid relating to the NFT purchase in US dollars. This includes royalty payments to creators and platform fees. Please note, this does not include the gas fee.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_transfer_doc.md
+++ b/models/doc_descriptions/nft/nft_transfer_doc.md
@@ -1,0 +1,5 @@
+{% docs nft_transfer_doc %}
+
+This table contains NFT transfer events on the Polygon blockchain.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_tx_fee.md
+++ b/models/doc_descriptions/nft/nft_tx_fee.md
@@ -1,0 +1,5 @@
+{% docs nft_tx_fee %}
+
+The gas fee for this transaction in MATIC. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_tx_fee_usd.md
+++ b/models/doc_descriptions/nft/nft_tx_fee_usd.md
@@ -1,0 +1,5 @@
+{% docs nft_tx_fee_usd %}
+
+The gas fee for this transaction in US dollars. 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_tx_hash.md
+++ b/models/doc_descriptions/nft/nft_tx_hash.md
@@ -1,0 +1,5 @@
+{% docs nft_tx_hash %}
+
+The transaction hash for the NFT event. This is not necessarily unique in this table as a transaction may contain multiple NFT events. 
+
+{% enddocs %}

--- a/models/gold/NFT/core__ez_nft_mints.sql
+++ b/models/gold/NFT/core__ez_nft_mints.sql
@@ -9,7 +9,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
-    a.contract_address AS nft_address,
+    A.contract_address AS nft_address,
     token_name AS project_name,
     from_address AS nft_from_address,
     to_address AS nft_to_address,

--- a/models/gold/NFT/core__ez_nft_sales.sql
+++ b/models/gold/NFT/core__ez_nft_sales.sql
@@ -2,7 +2,7 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
 ) }}
 
 SELECT

--- a/models/gold/NFT/core__ez_nft_sales.sql
+++ b/models/gold/NFT/core__ez_nft_sales.sql
@@ -2,135 +2,9 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
 ) }}
 
-WITH base AS (
-
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        event_type,
-        platform_address,
-        platform_name,
-        platform_exchange_version,
-        seller_address,
-        buyer_address,
-        nft_address,
-        erc1155_value,
-        tokenId,
-        currency_address,
-        price_raw,
-        total_fees_raw,
-        platform_fee_raw,
-        creator_fee_raw,
-        tx_fee,
-        origin_from_address,
-        origin_to_address,
-        origin_function_signature
-    FROM
-        {{ ref('silver__seaport_1_1') }}
-    UNION ALL
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        event_type,
-        platform_address,
-        platform_name,
-        platform_exchange_version,
-        seller_address,
-        buyer_address,
-        nft_address,
-        erc1155_value,
-        tokenId,
-        currency_address,
-        price_raw,
-        total_fees_raw,
-        platform_fee_raw,
-        creator_fee_raw,
-        tx_fee,
-        origin_from_address,
-        origin_to_address,
-        origin_function_signature
-    FROM
-        {{ ref('silver__seaport_1_4') }}
-    UNION ALL
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        event_type,
-        platform_address,
-        platform_name,
-        platform_exchange_version,
-        seller_address,
-        buyer_address,
-        nft_address,
-        erc1155_value,
-        tokenId,
-        currency_address,
-        price_raw,
-        total_fees_raw,
-        platform_fee_raw,
-        creator_fee_raw,
-        tx_fee,
-        origin_from_address,
-        origin_to_address,
-        origin_function_signature
-    FROM
-        {{ ref('silver__seaport_1_5') }}
-),
-all_prices AS (
-    SELECT
-        HOUR,
-        token_address,
-        symbol,
-        price AS hourly_price,
-        decimals
-    FROM
-        {{ ref('silver__prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                base
-        )
-    UNION ALL
-    SELECT
-        HOUR,
-        'MATIC' AS token_address,
-        'MATIC' AS symbol,
-        price AS hourly_price,
-        decimals
-    FROM
-        {{ ref('silver__prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                base
-        )
-        AND token_address = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
-),
-matic_price AS (
-    SELECT
-        HOUR,
-        price AS matic_hourly_price
-    FROM
-        {{ ref('silver__prices') }}
-    WHERE
-        HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                base
-        )
-        AND token_address = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
-)
 SELECT
     block_number,
     block_timestamp,
@@ -139,95 +13,27 @@ SELECT
     platform_address,
     platform_name,
     platform_exchange_version,
+    aggregator_name,
     seller_address,
     buyer_address,
     nft_address,
-    cc1.token_name AS project_name,
+    project_name,
     erc1155_value,
     tokenId,
-    CASE
-        WHEN currency_address = 'MATIC' THEN 'MATIC'
-        ELSE p.symbol
-    END AS currency_symbol,
+    currency_symbol,
     currency_address,
-    CASE
-        WHEN currency_address IN (
-            'MATIC',
-            '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
-        ) THEN price_raw / pow(
-            10,
-            18
-        )
-        ELSE COALESCE (price_raw / pow(10, decimals), price_raw)
-    END AS price,
-    IFF(
-        decimals IS NULL,
-        0,
-        price * hourly_price
-    ) AS price_usd,
-    CASE
-        WHEN currency_address IN (
-            'MATIC',
-            '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
-        ) THEN total_fees_raw / pow(
-            10,
-            18
-        )
-        ELSE COALESCE (total_fees_raw / pow(10, decimals), total_fees_raw)
-    END AS total_fees,
-    CASE
-        WHEN currency_address IN (
-            'MATIC',
-            '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
-        ) THEN platform_fee_raw / pow(
-            10,
-            18
-        )
-        ELSE COALESCE (platform_fee_raw / pow(10, decimals), platform_fee_raw)
-    END AS platform_fee,
-    CASE
-        WHEN currency_address IN (
-            'MATIC',
-            '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
-        ) THEN creator_fee_raw / pow(
-            10,
-            18
-        )
-        ELSE COALESCE (creator_fee_raw / pow(10, decimals), creator_fee_raw)
-    END AS creator_fee,
-    IFF(
-        decimals IS NULL,
-        0,
-        total_fees * hourly_price
-    ) AS total_fees_usd,
-    IFF(
-        decimals IS NULL,
-        0,
-        platform_fee * hourly_price
-    ) AS platform_fee_usd,
-    IFF(
-        decimals IS NULL,
-        0,
-        creator_fee * hourly_price
-    ) AS creator_fee_usd,
+    price,
+    price_usd,
+    total_fees,
+    platform_fee,
+    creator_fee,
+    total_fees_usd,
+    platform_fee_usd,
+    creator_fee_usd,
     tx_fee,
-    tx_fee * matic_hourly_price AS tx_fee_usd,
+    tx_fee_usd,
     origin_from_address,
     origin_to_address,
     origin_function_signature
 FROM
-    base b
-    LEFT JOIN all_prices p
-    ON DATE_TRUNC(
-        'hour',
-        b.block_timestamp
-    ) = p.hour
-    AND b.currency_address = p.token_address
-    LEFT JOIN matic_price m
-    ON DATE_TRUNC(
-        'hour',
-        b.block_timestamp
-    ) = m.hour
-    LEFT JOIN {{ ref('silver__contracts') }}
-    cc1
-    ON b.nft_address = cc1.contract_address
+    {{ ref('silver__complete_nft_sales') }}

--- a/models/gold/NFT/core__ez_nft_sales.yml
+++ b/models/gold/NFT/core__ez_nft_sales.yml
@@ -1,62 +1,66 @@
 version: 2
 models:
   - name: core__ez_nft_sales
-    description: This table contains NFT sales from Opensea Seaport 1.1 and 1.4 on Polygon.
+    description: This table contains NFT sales from Opensea Seaport 1.1, 1.4 and 1.5 on Polygon.
 
     columns:
       - name: BLOCK_NUMBER
-        description: The block number of the NFT sale.
+        description: '{{ doc("nft_block_no") }}'   
       - name: BLOCK_TIMESTAMP
-        description: The block timestamp of the NFT sale.
+        description: '{{ doc("nft_blocktime") }}'
       - name: TX_HASH
-        description: The transaction hash of the NFT sale. Please note this is not unique, as it is possible to have multiple NFT sales in a single transaction.
+        description: '{{ doc("nft_tx_hash") }}'
       - name: EVENT_TYPE
-        description: The event type of the NFT sale, can be either `sale` or `bid_won`.
+        description: '{{ doc("nft_event_type") }}'
       - name: PLATFORM_ADDRESS
-        description: The address of the NFT platform.
+        description: '{{ doc("nft_platform_address") }}'
       - name: PLATFORM_NAME
-        description: The name of the NFT platform.
+        description: '{{ doc("nft_platform_name") }}'
       - name: PLATFORM_EXCHANGE_VERSION
-        description: The version of the NFT platform, for example `1.1` or `1.4`.
+        description: '{{ doc("nft_platform_exchange_version") }}'
+      - name: AGGREGATOR_NAME
+        description: '{{ doc("nft_aggregator_name") }}'
       - name: SELLER_ADDRESS
-        description: The address of the seller of the NFT.
+        description: '{{ doc("nft_seller_address") }}'
       - name: BUYER_ADDRESS
-        description: The address of the buyer of the NFT.
+        description: '{{ doc("nft_buyer_address") }}'
       - name: NFT_ADDRESS
-        description: The address of the NFT contract.
+        description: '{{ doc("nft_nft_address") }}'
       - name: PROJECT_NAME
-        description: The name of the project, read from the NFT contract.
+        description: '{{ doc("nft_project_name") }}'
       - name: ERC1155_VALUE
-        description: The value of the ERC1155 transfer. This is only populated for ERC1155 transfers.
+        description: '{{ doc("nft_erc1155_value") }}'
       - name: TOKENID
-        description: The token ID of the NFT sale.
+        description: '{{ doc("nft_tokenid") }}'
+      - name: TOKEN_METADATA
+        description: '{{ doc("nft_metadata") }}'
       - name: CURRENCY_SYMBOL
-        description: The currency symbol of the NFT sale.
+        description: '{{ doc("nft_currency_symbol") }}'
       - name: CURRENCY_ADDRESS
-        description: The address of the currency used for the NFT sale.
+        description: '{{ doc("nft_currency_address") }}'
       - name: PRICE
-        description: The total price of the NFT sale, in the currency specified by `CURRENCY_SYMBOL`, including fees.
+        description: '{{ doc("nft_price") }}'
       - name: PRICE_USD
-        description: The total price of the NFT sale, in USD, including fees.
+        description: '{{ doc("nft_price_usd") }}'
       - name: TOTAL_FEES
-        description: The total fees of the NFT sale, in the currency specified by `CURRENCY_SYMBOL`.
+        description: '{{ doc("nft_total_fees") }}'
       - name: PLATFORM_FEE
-        description: The platform fee of the NFT sale, in the currency specified by `CURRENCY_SYMBOL`.
+        description: '{{ doc("nft_platform_fee") }}'
       - name: CREATOR_FEE
-        description: The creator fee of the NFT sale, in the currency specified by `CURRENCY_SYMBOL`.
+        description: '{{ doc("nft_creator_fee") }}'
       - name: TOTAL_FEES_USD
-        description: The total fees of the NFT sale, in USD.
+        description: '{{ doc("nft_total_fees_usd") }}'
       - name: PLATFORM_FEE_USD
-        description: The platform fee of the NFT sale, in USD.
+        description: '{{ doc("nft_platform_fee_usd") }}'
       - name: CREATOR_FEE_USD
-        description: The creator fee of the NFT sale, in USD.
+        description: '{{ doc("nft_creator_fee_usd") }}'
       - name: TX_FEE
-        description: The transaction fee in MATIC of the NFT sale.
+        description: '{{ doc("nft_tx_fee") }}'
       - name: TX_FEE_USD
-        description: The transaction fee in USD of the NFT sale.
+        description: '{{ doc("nft_tx_fee_usd") }}'
       - name: ORIGIN_FROM_ADDRESS
-        description: The address of the transaction sender.
+        description: '{{ doc("nft_origin_from") }}'
       - name: ORIGIN_TO_ADDRESS
-        description: The address of the transaction recipient, often the platform address.
+        description: '{{ doc("nft_origin_to") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE
-        description: The function signature of the transaction.
+        description: '{{ doc("nft_origin_sig") }}'

--- a/models/silver/NFT/silver__complete_nft_sales.sql
+++ b/models/silver/NFT/silver__complete_nft_sales.sql
@@ -1,0 +1,414 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'nft_log_id',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime']
+) }}
+
+WITH nft_base_models AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_type,
+        platform_address,
+        platform_name,
+        platform_exchange_version,
+        seller_address,
+        buyer_address,
+        nft_address,
+        erc1155_value,
+        tokenId,
+        currency_address,
+        total_price_raw,
+        total_fees_raw,
+        platform_fee_raw,
+        creator_fee_raw,
+        tx_fee,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        input_data,
+        nft_log_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__seaport_1_1_sales') }}
+
+{% if is_incremental() %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) :: DATE - 1
+        FROM
+            {{ this }}
+    )
+{% endif %}
+UNION ALL
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_type,
+    platform_address,
+    platform_name,
+    platform_exchange_version,
+    seller_address,
+    buyer_address,
+    nft_address,
+    erc1155_value,
+    tokenId,
+    currency_address,
+    total_price_raw,
+    total_fees_raw,
+    platform_fee_raw,
+    creator_fee_raw,
+    tx_fee,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    input_data,
+    nft_log_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    {{ ref('silver__seaport_1_4_sales') }}
+
+{% if is_incremental() %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) :: DATE - 1
+        FROM
+            {{ this }}
+    )
+{% endif %}
+UNION ALL
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_type,
+    platform_address,
+    platform_name,
+    platform_exchange_version,
+    seller_address,
+    buyer_address,
+    nft_address,
+    erc1155_value,
+    tokenId,
+    currency_address,
+    total_price_raw,
+    total_fees_raw,
+    platform_fee_raw,
+    creator_fee_raw,
+    tx_fee,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    input_data,
+    nft_log_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    {{ ref('silver__seaport_1_5_sales') }}
+
+{% if is_incremental() %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) :: DATE - 1
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
+prices_raw AS (
+    SELECT
+        HOUR,
+        symbol,
+        token_address,
+        decimals,
+        price AS hourly_prices
+    FROM
+        {{ ref('silver__prices') }}
+    WHERE
+        HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                nft_base_models
+        )
+        AND token_address IN (
+            SELECT
+                DISTINCT currency_address
+            FROM
+                nft_base_models
+        )
+
+{% if is_incremental() %}
+AND HOUR >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 2
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+all_prices AS (
+    SELECT
+        HOUR,
+        token_address,
+        symbol,
+        hourly_prices,
+        decimals
+    FROM
+        prices_raw
+    UNION ALL
+    SELECT
+        HOUR,
+        'MATIC' AS token_address,
+        'MATIC' AS symbol,
+        hourly_prices,
+        decimals
+    FROM
+        prices_raw
+    WHERE
+        token_address = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+),
+matic_price AS (
+    SELECT
+        HOUR,
+        hourly_prices AS matic_hourly_price
+    FROM
+        prices_raw
+    WHERE
+        token_address = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+),
+final_base AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_type,
+        platform_address,
+        platform_name,
+        platform_exchange_version,
+        NULL AS aggregator_name,
+        seller_address,
+        buyer_address,
+        nft_address,
+        C.token_name AS project_name,
+        erc1155_value,
+        tokenId,
+        CASE
+            WHEN currency_address = 'MATIC' THEN 'MATIC'
+            ELSE p.symbol
+        END AS currency_symbol,
+        currency_address,
+        total_price_raw,
+        total_fees_raw,
+        platform_fee_raw,
+        creator_fee_raw,
+        CASE
+            WHEN currency_address IN (
+                'MATIC',
+                '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+            ) THEN total_price_raw / pow(
+                10,
+                18
+            )
+            ELSE COALESCE (total_price_raw / pow(10, decimals), total_price_raw)
+        END AS price,
+        IFF(
+            decimals IS NULL,
+            0,
+            price * hourly_prices
+        ) AS price_usd,
+        CASE
+            WHEN currency_address IN (
+                'MATIC',
+                '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+            ) THEN total_fees_raw / pow(
+                10,
+                18
+            )
+            ELSE COALESCE (total_fees_raw / pow(10, decimals), total_fees_raw)
+        END AS total_fees,
+        CASE
+            WHEN currency_address IN (
+                'MATIC',
+                '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+            ) THEN platform_fee_raw / pow(
+                10,
+                18
+            )
+            ELSE COALESCE (platform_fee_raw / pow(10, decimals), platform_fee_raw)
+        END AS platform_fee,
+        CASE
+            WHEN currency_address IN (
+                'MATIC',
+                '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+            ) THEN creator_fee_raw / pow(
+                10,
+                18
+            )
+            ELSE COALESCE (creator_fee_raw / pow(10, decimals), creator_fee_raw)
+        END AS creator_fee,
+        IFF(
+            decimals IS NULL,
+            0,
+            total_fees * hourly_prices
+        ) AS total_fees_usd,
+        IFF(
+            decimals IS NULL,
+            0,
+            platform_fee * hourly_prices
+        ) AS platform_fee_usd,
+        IFF(
+            decimals IS NULL,
+            0,
+            creator_fee * hourly_prices
+        ) AS creator_fee_usd,
+        tx_fee,
+        tx_fee * matic_hourly_price AS tx_fee_usd,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        input_data,
+        nft_log_id,
+        _log_id,
+        b._inserted_timestamp
+    FROM
+        nft_base_models b
+        LEFT JOIN all_prices p
+        ON DATE_TRUNC(
+            'hour',
+            b.block_timestamp
+        ) = p.hour
+        AND b.currency_address = p.token_address
+        LEFT JOIN matic_price m
+        ON DATE_TRUNC(
+            'hour',
+            b.block_timestamp
+        ) = m.hour
+        LEFT JOIN {{ ref('silver__contracts') }} C
+        ON b.nft_address = C.contract_address
+)
+
+{% if is_incremental() %},
+label_fill_sales AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_type,
+        platform_address,
+        platform_name,
+        platform_exchange_version,
+        NULL AS aggregator_name,
+        seller_address,
+        buyer_address,
+        nft_address,
+        C.token_name AS project_name,
+        erc1155_value,
+        tokenId,
+        currency_symbol,
+        currency_address,
+        total_price_raw,
+        total_fees_raw,
+        platform_fee_raw,
+        creator_fee_raw,
+        price,
+        price_usd,
+        total_fees,
+        total_fees_usd,
+        platform_fee,
+        platform_fee_usd,
+        creator_fee,
+        creator_fee_usd,
+        tx_fee,
+        tx_fee_usd,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        input_data,
+        nft_log_id,
+        _log_id,
+        GREATEST(
+            t._inserted_timestamp,
+            C._inserted_timestamp
+        ) AS _inserted_timestamp
+    FROM
+        {{ this }}
+        t
+        INNER JOIN {{ ref('silver__contracts') }} C
+        ON t.nft_address = C.contract_address
+    WHERE
+        t.project_name IS NULL
+        AND C.token_name IS NOT NULL
+)
+{% endif %},
+final_joins AS (
+    SELECT
+        *
+    FROM
+        final_base
+
+{% if is_incremental() %}
+UNION
+SELECT
+    *
+FROM
+    label_fill_sales
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_type,
+    platform_address,
+    platform_name,
+    platform_exchange_version,
+    aggregator_name,
+    seller_address,
+    buyer_address,
+    nft_address,
+    project_name,
+    erc1155_value,
+    tokenId,
+    currency_symbol,
+    currency_address,
+    total_price_raw,
+    total_fees_raw,
+    platform_fee_raw,
+    creator_fee_raw,
+    price,
+    price_usd,
+    total_fees,
+    total_fees_usd,
+    platform_fee,
+    platform_fee_usd,
+    creator_fee,
+    creator_fee_usd,
+    tx_fee,
+    tx_fee_usd,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    nft_log_id,
+    input_data,
+    _log_id,
+    _inserted_timestamp
+FROM
+    final_joins qualify(ROW_NUMBER() over(PARTITION BY nft_log_id
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/NFT/silver__complete_nft_sales.yml
+++ b/models/silver/NFT/silver__complete_nft_sales.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__seaport_1_5
+  - name: silver__complete_nft_sales 
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -21,6 +21,7 @@ models:
               interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
+                - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
       - name: TX_HASH
         tests:
@@ -35,8 +36,6 @@ models:
       - name: PLATFORM_NAME
         tests:
           - not_null
-          - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set: ['opensea']
       - name: SELLER_ADDRESS
         tests:
           - not_null
@@ -57,32 +56,56 @@ models:
           - not_null
       - name: CURRENCY_ADDRESS
         tests:
-          - not_null:
-              where: "price_raw > 0"
-      - name: PRICE_RAW
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER    
-                - FLOAT  
-      - name: TOTAL_FEES_RAW
+          - not_null: 
+              where: platform_exchange_version not in ('seaport_1_1', 'seaport_1_4', 'seaport_1_5') 
+      - name: PRICE
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER    
                 - FLOAT 
-      - name: PLATFORM_FEE_RAW
+      - name: PRICE_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT  
+      - name: TOTAL_FEES
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: PLATFORM_FEE
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER    
                 - FLOAT
-      - name: CREATOR_FEE_RAW
+      - name: CREATOR_FEE
         tests:
           - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: TOTAL_FEES_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: PLATFORM_FEE_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: CREATOR_FEE_USD
+        tests:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER    
@@ -93,19 +116,13 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER    
-                - FLOAT  
+                - FLOAT 
       - name: NFT_LOG_ID
         tests:
-          - not_null
-      - name: _INSERTED_TIMESTAMP
+          - not_null 
+      - name: _LOG_ID
         tests:
-          - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - TIMESTAMP_NTZ
+          - not_null 
       - name: ORIGIN_FROM_ADDRESS
         tests:
           - not_null
@@ -124,8 +141,6 @@ models:
       - name: EVENT_TYPE
         tests:
           - not_null
-          - dbt_expectations.expect_column_values_to_be_in_set:
-              value_set: ['bid_won', 'sale']
       - name: INPUT_DATA
         tests:
           - not_null

--- a/models/silver/NFT/silver__seaport_1_1_sales.sql
+++ b/models/silver/NFT/silver__seaport_1_1_sales.sql
@@ -1136,7 +1136,7 @@ SELECT
     COALESCE (
         total_sale_amount_raw,
         0
-    ) AS price_raw,
+    ) AS total_price_raw,
     COALESCE (
         total_fees_raw,
         0
@@ -1166,6 +1166,7 @@ SELECT
         '-',
         _log_id
     ) AS nft_log_id,
+    _log_id,
     _inserted_timestamp
 FROM
     base_sales_buy_and_offer s

--- a/models/silver/NFT/silver__seaport_1_1_sales.yml
+++ b/models/silver/NFT/silver__seaport_1_1_sales.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__seaport_1_4
+  - name: silver__seaport_1_1_sales
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -55,8 +55,8 @@ models:
       - name: CURRENCY_ADDRESS
         tests:
           - not_null:
-              where: "price_raw > 0"
-      - name: PRICE_RAW
+              where: "total_price_raw > 0"
+      - name: TOTAL_PRICE_RAW
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
@@ -90,7 +90,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER    
-                - FLOAT  
+                - FLOAT 
       - name: NFT_LOG_ID
         tests:
           - not_null
@@ -107,7 +107,6 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: ORIGIN_TO_ADDRESS
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
       - name: ORIGIN_FUNCTION_SIGNATURE

--- a/models/silver/NFT/silver__seaport_1_4_sales.sql
+++ b/models/silver/NFT/silver__seaport_1_4_sales.sql
@@ -23,8 +23,8 @@ raw_decoded_logs AS (
     FROM
         {{ ref('silver__decoded_logs') }}
     WHERE
-        block_number >= 42031942
-        AND contract_address = '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'
+        block_number >= 35000000
+        AND contract_address = '0x00000000000001ad428e4906ae43d8f9852d0dd6'
         AND event_name = 'OrderFulfilled'
 
 {% if is_incremental() %}
@@ -84,8 +84,8 @@ raw_logs AS (
     FROM
         {{ ref('silver__logs') }}
     WHERE
-        block_number >= 42031942
-        AND contract_address = '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'
+        block_number >= 35000000
+        AND contract_address = '0x00000000000001ad428e4906ae43d8f9852d0dd6'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -198,7 +198,7 @@ mao_orderhash AS (
             FROM
                 raw_logs
             WHERE
-                block_timestamp >= '2023-04-01'
+                block_timestamp >= '2023-02-01'
                 AND topics [0] = '0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31'
         ),
         decoded AS (
@@ -1715,7 +1715,7 @@ final_seaport AS (
         s.event_index,
         s.contract_address AS platform_address,
         'opensea' AS platform_name,
-        'seaport_1_5' AS platform_exchange_version,
+        'seaport_1_4' AS platform_exchange_version,
         s.event_name,
         offer_length,
         offerer AS seller_address,
@@ -1742,7 +1742,7 @@ final_seaport AS (
         COALESCE (
             total_sale_amount_raw,
             0
-        ) AS price_raw,
+        ) AS total_price_raw,
         COALESCE (
             total_fees_raw,
             0

--- a/models/silver/NFT/silver__seaport_1_4_sales.yml
+++ b/models/silver/NFT/silver__seaport_1_4_sales.yml
@@ -1,0 +1,125 @@
+version: 2
+models:
+  - name: silver__seaport_1_4_sales
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - nft_log_id
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM_NAME
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['opensea']
+      - name: SELLER_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: BUYER_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: NFT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKENID
+        tests:
+          - not_null
+      - name: CURRENCY_ADDRESS
+        tests:
+          - not_null:
+              where: "total_price_raw > 0"
+      - name: TOTAL_PRICE_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT  
+      - name: TOTAL_FEES_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: PLATFORM_FEE_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: CREATOR_FEE_RAW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: TX_FEE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT  
+      - name: NFT_LOG_ID
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_TYPE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['bid_won', 'sale']
+      - name: INPUT_DATA
+        tests:
+          - not_null

--- a/models/silver/NFT/silver__seaport_1_5_sales.sql
+++ b/models/silver/NFT/silver__seaport_1_5_sales.sql
@@ -23,8 +23,8 @@ raw_decoded_logs AS (
     FROM
         {{ ref('silver__decoded_logs') }}
     WHERE
-        block_number >= 35000000
-        AND contract_address = '0x00000000000001ad428e4906ae43d8f9852d0dd6'
+        block_number >= 42031942
+        AND contract_address = '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'
         AND event_name = 'OrderFulfilled'
 
 {% if is_incremental() %}
@@ -84,8 +84,8 @@ raw_logs AS (
     FROM
         {{ ref('silver__logs') }}
     WHERE
-        block_number >= 35000000
-        AND contract_address = '0x00000000000001ad428e4906ae43d8f9852d0dd6'
+        block_number >= 42031942
+        AND contract_address = '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -198,7 +198,7 @@ mao_orderhash AS (
             FROM
                 raw_logs
             WHERE
-                block_timestamp >= '2023-02-01'
+                block_timestamp >= '2023-04-01'
                 AND topics [0] = '0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31'
         ),
         decoded AS (
@@ -1715,7 +1715,7 @@ final_seaport AS (
         s.event_index,
         s.contract_address AS platform_address,
         'opensea' AS platform_name,
-        'seaport_1_4' AS platform_exchange_version,
+        'seaport_1_5' AS platform_exchange_version,
         s.event_name,
         offer_length,
         offerer AS seller_address,
@@ -1742,7 +1742,7 @@ final_seaport AS (
         COALESCE (
             total_sale_amount_raw,
             0
-        ) AS price_raw,
+        ) AS total_price_raw,
         COALESCE (
             total_fees_raw,
             0

--- a/models/silver/NFT/silver__seaport_1_5_sales.yml
+++ b/models/silver/NFT/silver__seaport_1_5_sales.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver__seaport_1_1
+  - name: silver__seaport_1_5_sales
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -16,6 +16,9 @@ models:
       - name: BLOCK_TIMESTAMP
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
@@ -55,8 +58,8 @@ models:
       - name: CURRENCY_ADDRESS
         tests:
           - not_null:
-              where: "price_raw > 0"
-      - name: PRICE_RAW
+              where: "total_price_raw > 0"
+      - name: TOTAL_PRICE_RAW
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
@@ -90,13 +93,16 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER    
-                - FLOAT 
+                - FLOAT  
       - name: NFT_LOG_ID
         tests:
           - not_null
       - name: _INSERTED_TIMESTAMP
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
@@ -107,6 +113,7 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: ORIGIN_TO_ADDRESS
         tests:
+          - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
       - name: ORIGIN_FUNCTION_SIGNATURE


### PR DESCRIPTION
1. Add join logic for newly created nft address names - in nft transfers & complete sales
2. Standardise nft transfers base model
3. Standardise seaport models
4. Standardise docs to drop chain prefix and use 'nft_' prefix