### PR TITLE
AN-3954/delete-insert-strategy

### DIFF
--- a/models/silver/NFT/silver__complete_nft_sales.sql
+++ b/models/silver/NFT/silver__complete_nft_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -41,8 +42,8 @@ WHERE
     _inserted_timestamp >= (
         SELECT
             MAX(
-                _inserted_timestamp
-            ) :: DATE - 1
+            _inserted_timestamp
+        ) - INTERVAL '24 hours'
         FROM
             {{ this }}
     )
@@ -82,8 +83,8 @@ WHERE
     _inserted_timestamp >= (
         SELECT
             MAX(
-                _inserted_timestamp
-            ) :: DATE - 1
+            _inserted_timestamp
+        ) - INTERVAL '24 hours'
         FROM
             {{ this }}
     )
@@ -123,8 +124,8 @@ WHERE
     _inserted_timestamp >= (
         SELECT
             MAX(
-                _inserted_timestamp
-            ) :: DATE - 1
+            _inserted_timestamp
+        ) - INTERVAL '24 hours'
         FROM
             {{ this }}
     )
@@ -156,7 +157,7 @@ prices_raw AS (
 {% if is_incremental() %}
 AND HOUR >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '48 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/NFT/silver__complete_nft_sales.sql
+++ b/models/silver/NFT/silver__complete_nft_sales.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
+    unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -43,7 +43,7 @@ WHERE
         SELECT
             MAX(
             _inserted_timestamp
-        ) - INTERVAL '24 hours'
+        ) - INTERVAL '36 hours'
         FROM
             {{ this }}
     )
@@ -84,7 +84,7 @@ WHERE
         SELECT
             MAX(
             _inserted_timestamp
-        ) - INTERVAL '24 hours'
+        ) - INTERVAL '36 hours'
         FROM
             {{ this }}
     )
@@ -125,7 +125,7 @@ WHERE
         SELECT
             MAX(
             _inserted_timestamp
-        ) - INTERVAL '24 hours'
+        ) - INTERVAL '36 hours'
         FROM
             {{ this }}
     )
@@ -153,15 +153,6 @@ prices_raw AS (
             FROM
                 nft_base_models
         )
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '48 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
 ),
 all_prices AS (
     SELECT

--- a/models/silver/NFT/silver__nft_transfers.sql
+++ b/models/silver/NFT/silver__nft_transfers.sql
@@ -1,8 +1,8 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    merge_update_columns = ["_log_id"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
     tags = ['non_realtime']
 ) }}

--- a/models/silver/NFT/silver__seaport_1_1_sales.sql
+++ b/models/silver/NFT/silver__seaport_1_1_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -33,7 +34,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -76,7 +77,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1053,7 +1054,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1096,7 +1097,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/NFT/silver__seaport_1_4_sales.sql
+++ b/models/silver/NFT/silver__seaport_1_4_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -32,7 +33,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -92,7 +93,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1658,7 +1659,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1701,7 +1702,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/NFT/silver__seaport_1_5_sales.sql
+++ b/models/silver/NFT/silver__seaport_1_5_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -32,7 +33,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -92,7 +93,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1658,7 +1659,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1701,7 +1702,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -60,7 +61,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -1,10 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
-
--- full_refresh = false,
 
 WITH contract_deployments AS (
 
@@ -32,7 +32,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -72,7 +73,7 @@ curve_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -119,7 +120,7 @@ token_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -67,7 +68,7 @@ sell_base_token AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -120,7 +121,7 @@ buy_base_token AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -42,7 +43,7 @@ WITH pools AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -92,7 +93,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -36,7 +37,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -67,7 +68,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -42,7 +43,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -67,7 +68,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -80,7 +81,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/quickswap/silver_dex__quickswap_v2_pools.sql
+++ b/models/silver/dex/quickswap/silver_dex__quickswap_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/quickswap/silver_dex__quickswap_v2_swaps.sql
+++ b/models/silver/dex/quickswap/silver_dex__quickswap_v2_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/quickswap/silver_dex__quickswap_v3_pools.sql
+++ b/models/silver/dex/quickswap/silver_dex__quickswap_v3_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['_inserted_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -28,7 +29,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/quickswap/silver_dex__quickswap_v3_swaps.sql
+++ b/models/silver/dex/quickswap/silver_dex__quickswap_v3_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -45,7 +46,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_id",
+  incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -42,7 +43,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -75,7 +76,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -103,7 +104,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -131,7 +132,7 @@ WHERE token0 IS NOT NULL
 AND
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -158,7 +159,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -185,7 +186,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -212,7 +213,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -240,7 +241,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -267,7 +268,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -294,7 +295,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -321,7 +322,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -349,7 +350,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,7 +1,7 @@
 {{ config(
   materialized = 'incremental',
   incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -27,6 +27,7 @@ SELECT
     pool_address,
     pool_name,
     'balancer' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp,
     token0,
@@ -60,6 +61,7 @@ SELECT
     pool_address,
     pool_name,
     'curve' AS platform,
+    'v1' AS version,
     _call_id AS _id,
     _inserted_timestamp,
     MAX(CASE WHEN token_num = 1 THEN token_address END) AS token0,
@@ -96,6 +98,7 @@ SELECT
     base_token AS token0,
     quote_token AS token1,
     'dodo-v1' AS platform,
+    'v1' AS version,
     _id,
     _inserted_timestamp
 FROM 
@@ -123,6 +126,7 @@ SELECT
     base_token AS token0,
     quote_token AS token1,
     'dodo-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM 
@@ -151,6 +155,7 @@ SELECT
     token0,
     token1,
     'fraxswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -178,6 +183,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v1' AS platform,
+    'v1-dynamic' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -205,6 +211,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v1' AS platform,
+    'v1-static' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -233,6 +240,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -260,6 +268,7 @@ SELECT
     token0,
     token1,
     'quickswap-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -287,6 +296,7 @@ SELECT
     token0_address AS token0,
     token1_address AS token1,
     'quickswap-v3' AS platform,
+    'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -314,6 +324,7 @@ SELECT
     token0,
     token1,
     'sushiswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -342,6 +353,7 @@ SELECT
     token0_address AS token0,
     token1_address AS token1,
     'uniswap-v3' AS platform,
+    'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -419,6 +431,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_standard p 
@@ -443,6 +456,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_v3 p 
@@ -475,6 +489,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol, 'token3', c3.symbol, 'token4', c4.symbol, 'token5', c5.symbol, 'token6', c6.symbol, 'token7', c7.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals, 'token3', c3.decimals, 'token4', c4.decimals, 'token5', c5.decimals, 'token6', c6.decimals, 'token7', c7.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_other p
@@ -501,6 +516,7 @@ SELECT
     block_timestamp,
     tx_hash,
     platform,
+    version,
     contract_address,
     pool_address,
     pool_name,

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_log_id",
+  incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -33,7 +34,7 @@ prices AS (
 {% if is_incremental() %}
 AND HOUR >= (
   SELECT
-    MAX(_inserted_timestamp) :: DATE - 2
+    MAX(_inserted_timestamp) - INTERVAL '48 hours'
   FROM
     {{ this }}
 )
@@ -134,7 +135,7 @@ univ3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -207,7 +208,7 @@ woofi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -258,7 +259,7 @@ kyberswap_v1_dynamic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -309,7 +310,7 @@ kyberswap_v1_static AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -360,7 +361,7 @@ kyberswap_v2_elastic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -411,7 +412,7 @@ fraxswap_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -462,7 +463,7 @@ sushi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -530,7 +531,7 @@ curve_swaps AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
   SELECT
-    MAX(_inserted_timestamp) :: DATE - 1
+    MAX(_inserted_timestamp) - INTERVAL '12 hours'
   FROM
     {{ this }}
 )
@@ -581,7 +582,7 @@ balancer_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -683,7 +684,7 @@ quickswap_v3_swaps AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
   SELECT
-    MAX(_inserted_timestamp) :: DATE - 1
+    MAX(_inserted_timestamp) - INTERVAL '12 hours'
   FROM
     {{ this }}
 )
@@ -734,7 +735,7 @@ quickswap_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -785,7 +786,7 @@ dodo_v1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -836,7 +837,7 @@ dodo_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'created_block',
     cluster_by = ['_inserted_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -37,7 +38,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -63,7 +64,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -45,7 +46,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -66,7 +67,7 @@ WITH router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -136,7 +137,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -31,7 +31,7 @@ AND p._inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )


### PR DESCRIPTION
1. Changes incremental strategy to delete+insert on `block_number` in majority of logs based downstream models
2. Minimizes incremental lookback to rolling 12 hrs vs 1-3 days, with exceptions
3. FR complete_dex_swaps, complete_lps, nft_transfers, and silver.transfers to resolve nulls and add version columns