### PR TITLE
add/decoder-history-ranges

### DIFF
--- a/.github/workflows/dbt_run_streamline_decoder_history_range_6.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history_range_6.yml
@@ -1,0 +1,45 @@
+name: dbt_run_streamline_decoder_history_range_6
+run-name: dbt_run_streamline_decoder_history_range_6
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs "at 10:00 UTC PM" (see https://crontab.guru)
+    - cron: '0 22 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":120,"row_limit":2400000}' -m "polygon_models,tag:streamline_decoded_logs_complete" "polygon_models,tag:streamline_decoded_logs_history_range_6"

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053000001_053050001.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053000001_053050001.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053050002_053100002.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053050002_053100002.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053100003_053150003.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053100003_053150003.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053150004_053200004.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053150004_053200004.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053200005_053250005.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053200005_053250005.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053250006_053300006.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053250006_053300006.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053300007_053350007.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053300007_053350007.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053350008_053400008.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053350008_053400008.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053400009_053450009.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053400009_053450009.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053450010_053500010.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053450010_053500010.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053500011_053550011.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053500011_053550011.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053550012_053600012.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053550012_053600012.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053600013_053650013.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053600013_053650013.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053650014_053700014.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053650014_053700014.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053700015_053750015.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053700015_053750015.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053750016_053800016.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053750016_053800016.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053800017_053850017.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053800017_053850017.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053850018_053900018.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053850018_053900018.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053900019_053950019.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053900019_053950019.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053950020_054000020.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_053950020_054000020.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054000021_054050021.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054000021_054050021.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054050022_054100022.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054050022_054100022.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054100023_054150023.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054100023_054150023.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054150024_054200024.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054150024_054200024.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054200025_054250025.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054200025_054250025.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054250026_054300026.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054250026_054300026.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054300027_054350027.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054300027_054350027.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054350028_054400028.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054350028_054400028.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054400029_054450029.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054400029_054450029.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054450030_054500030.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054450030_054500030.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054500031_054550031.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054500031_054550031.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054550032_054600032.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054550032_054600032.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054600033_054650033.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054600033_054650033.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054650034_054700034.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054650034_054700034.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054700035_054750035.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054700035_054750035.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054750036_054800036.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054750036_054800036.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054800037_054850037.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054800037_054850037.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054850038_054900038.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054850038_054900038.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054900039_054950039.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054900039_054950039.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054950040_055000040.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_054950040_055000040.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055000041_055050041.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055000041_055050041.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055050042_055100042.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055050042_055100042.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055100043_055150043.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055100043_055150043.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055150044_055200044.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055150044_055200044.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055200045_055250045.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055200045_055250045.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055250046_055300046.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055250046_055300046.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055300047_055350047.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055300047_055350047.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055350048_055400048.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055350048_055400048.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055400049_055450049.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055400049_055450049.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055450050_055500050.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055450050_055500050.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055500051_055550051.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055500051_055550051.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055550052_055600052.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055550052_055600052.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055600053_055650053.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055600053_055650053.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055650054_055700054.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055650054_055700054.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055700055_055750055.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055700055_055750055.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055750056_055800056.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055750056_055800056.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055800057_055850057.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055800057_055850057.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055850058_055900058.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055850058_055900058.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055900059_055950059.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055900059_055950059.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055950060_056000060.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_055950060_056000060.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056000061_056050061.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056000061_056050061.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056050062_056100062.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056050062_056100062.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056100063_056150063.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056100063_056150063.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056150064_056200064.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056150064_056200064.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056200065_056250065.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056200065_056250065.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056250066_056300066.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056250066_056300066.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056300067_056350067.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056300067_056350067.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056350068_056400068.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056350068_056400068.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056400069_056450069.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056400069_056450069.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056450070_056500070.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056450070_056500070.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056500071_056550071.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056500071_056550071.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056550072_056600072.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056550072_056600072.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056600073_056650073.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056600073_056650073.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056650074_056700074.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056650074_056700074.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056700075_056750075.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056700075_056750075.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056750076_056800076.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056750076_056800076.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056800077_056850077.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056800077_056850077.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056850078_056900078.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056850078_056900078.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056900079_056950079.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056900079_056950079.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056950080_057000080.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_056950080_057000080.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057000081_057050081.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057000081_057050081.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057050082_057100082.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057050082_057100082.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057100083_057150083.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057100083_057150083.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057150084_057200084.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057150084_057200084.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057200085_057250085.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057200085_057250085.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057250086_057300086.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057250086_057300086.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057300087_057350087.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057300087_057350087.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057350088_057400088.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057350088_057400088.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057400089_057450089.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057400089_057450089.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057450090_057500090.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057450090_057500090.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057500091_057550091.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057500091_057550091.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057550092_057600092.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057550092_057600092.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057600093_057650093.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057600093_057650093.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057650094_057700094.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057650094_057700094.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057700095_057750095.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057700095_057750095.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057750096_057800096.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057750096_057800096.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057800097_057850097.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057800097_057850097.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057850098_057900098.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057850098_057900098.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057900099_057950099.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057900099_057950099.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057950100_058000100.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_057950100_058000100.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058000101_058050101.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058000101_058050101.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058050102_058100102.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058050102_058100102.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058100103_058150103.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058100103_058150103.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058150104_058200104.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058150104_058200104.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058200105_058250105.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058200105_058250105.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058250106_058300106.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058250106_058300106.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058300107_058350107.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058300107_058350107.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058350108_058400108.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058350108_058400108.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058400109_058450109.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058400109_058450109.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058450110_058500110.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058450110_058500110.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058500111_058550111.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058500111_058550111.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058550112_058600112.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058550112_058600112.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058600113_058650113.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058600113_058650113.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058650114_058700114.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058650114_058700114.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058700115_058750115.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058700115_058750115.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058750116_058800116.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058750116_058800116.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058800117_058850117.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058800117_058850117.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058850118_058900118.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058850118_058900118.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058900119_058950119.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058900119_058950119.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058950120_059000120.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_058950120_059000120.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059000121_059050121.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059000121_059050121.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059050122_059100122.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059050122_059100122.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059100123_059150123.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059100123_059150123.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059150124_059200124.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059150124_059200124.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059200125_059250125.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059200125_059250125.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059250126_059300126.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059250126_059300126.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059300127_059350127.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059300127_059350127.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059350128_059400128.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059350128_059400128.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059400129_059450129.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059400129_059450129.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059450130_059500130.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059450130_059500130.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059500131_059550131.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059500131_059550131.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059550132_059600132.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059550132_059600132.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059600133_059650133.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059600133_059650133.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059650134_059700134.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059650134_059700134.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059700135_059750135.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059700135_059750135.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059750136_059800136.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059750136_059800136.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059800137_059850137.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059800137_059850137.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059850138_059900138.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059850138_059900138.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059900139_059950139.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059900139_059950139.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059950140_060000140.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_059950140_060000140.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060000141_060050141.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060000141_060050141.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060050142_060100142.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060050142_060100142.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060100143_060150143.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060100143_060150143.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060150144_060200144.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060150144_060200144.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060200145_060250145.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060200145_060250145.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060250146_060300146.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060250146_060300146.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060300147_060350147.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060300147_060350147.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060350148_060400148.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060350148_060400148.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060400149_060450149.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060400149_060450149.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060450150_060500150.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060450150_060500150.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060500151_060550151.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060500151_060550151.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060550152_060600152.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060550152_060600152.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060600153_060650153.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060600153_060650153.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060650154_060700154.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060650154_060700154.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060700155_060750155.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060700155_060750155.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060750156_060800156.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060750156_060800156.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060800157_060850157.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060800157_060850157.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060850158_060900158.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060850158_060900158.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060900159_060950159.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060900159_060950159.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060950160_061000160.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_060950160_061000160.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061000161_061050161.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061000161_061050161.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061050162_061100162.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061050162_061100162.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061100163_061150163.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061100163_061150163.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061150164_061200164.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061150164_061200164.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061200165_061250165.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061200165_061250165.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061250166_061300166.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061250166_061300166.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061300167_061350167.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061300167_061350167.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061350168_061400168.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061350168_061400168.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061400169_061450169.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061400169_061450169.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061450170_061500170.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061450170_061500170.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061500171_061550171.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061500171_061550171.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061550172_061600172.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061550172_061600172.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061600173_061650173.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061600173_061650173.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061650174_061700174.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061650174_061700174.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061700175_061750175.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061700175_061750175.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061750176_061800176.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061750176_061800176.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061800177_061850177.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_061800177_061850177.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}


### PR DESCRIPTION
 Requires `dbt run -m models/streamline/silver/decoder/history/range_6 --full-refresh` + run history job