### PR TITLE
fix decoded_logs_history _log_id error

### DIFF
--- a/macros/decoder/decoded_logs_history.sql
+++ b/macros/decoder/decoded_logs_history.sql
@@ -42,7 +42,7 @@
               {% endif %}
           ),
           existing_logs_to_exclude AS (
-              SELECT CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id
+              SELECT _log_id
               FROM {{ ref('streamline__decoded_logs_complete') }} l
               INNER JOIN target_blocks b using (block_number)
           ),


### PR DESCRIPTION
- removed `CONCAT(TX_HASH :: STRING, '-', EVENT_INDEX :: STRING) AS _log_id` and replaced with `_log_id` in `existing_logs_to_exclude ` cte as underlying `decoded_logs_complete` table do not have `tx_hash` column.