### PR TITLE
AN-5873/old-udfs

### DIFF
--- a/models/bronze/api_udf/bronze_api__token_reads.sql
+++ b/models/bronze/api_udf/bronze_api__token_reads.sql
@@ -53,39 +53,45 @@ ready_reads AS (
         contract_address,
         latest_block,
         function_sig,
-        CONCAT(
-            '[\'',
-            contract_address,
-            '\',',
-            latest_block,
-            ',\'',
+        RPAD(
             function_sig,
-            '\',\'\']'
-        ) AS read_input
+            64,
+            '0'
+        ) AS input,
+        utils.udf_json_rpc_call(
+            'eth_call',
+            [{'to': contract_address, 'from': null, 'data': input}, utils.udf_int_to_hex(latest_block)],
+            concat_ws(
+                '-',
+                contract_address,
+                input,
+                latest_block
+            )
+        ) AS rpc_request
     FROM
         all_reads
 ),
 batch_reads AS (
     SELECT
-        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+        ARRAY_AGG(rpc_request) AS batch_rpc_request
     FROM
         ready_reads
 ),
-results AS (
+node_call AS (
     SELECT
-        ethereum.streamline.udf_json_rpc_read_calls(
-            node_url,
-            headers,
-            PARSE_JSON(batch_read)
-        ) AS read_output
+        *,
+        live.udf_api(
+            'POST',
+            CONCAT(
+                '{Service}',
+                '/',
+                '{Authentication}'
+            ),{},
+            batch_rpc_request,
+            'Vault/prod/polygon/quicknode/mainnet'
+        ) AS response
     FROM
         batch_reads
-        JOIN {{ source(
-            'streamline_crosschain',
-            'node_mapping'
-        ) }}
-        ON 1 = 1
-        AND chain = 'polygon'
     WHERE
         EXISTS (
             SELECT
@@ -95,30 +101,30 @@ results AS (
             LIMIT
                 1
         )
-), FINAL AS (
+), flat_responses AS (
     SELECT
-        VALUE :id :: STRING AS read_id,
-        VALUE :result :: STRING AS read_result,
-        SPLIT(
-            read_id,
-            '-'
-        ) AS read_id_object,
-        read_id_object [0] :: STRING AS contract_address,
-        read_id_object [1] :: STRING AS block_number,
-        read_id_object [2] :: STRING AS function_sig,
-        read_id_object [3] :: STRING AS function_input
+        VALUE :id :: STRING AS call_id,
+        VALUE :result :: STRING AS read_result
     FROM
-        results,
-        LATERAL FLATTEN(
-            input => read_output [0] :data
+        node_call,
+        LATERAL FLATTEN (
+            input => response :data
         )
 )
 SELECT
-    contract_address,
-    block_number,
-    function_sig,
-    function_input,
+    SPLIT_PART(
+        call_id,
+        '-',
+        1
+    ) AS contract_address,
+    SPLIT_PART(
+        call_id,
+        '-',
+        3
+    ) AS block_number,
+    LEFT(SPLIT_PART(call_id, '-', 2), 10) AS function_sig,
+    NULL AS function_input,
     read_result,
     SYSDATE() :: TIMESTAMP AS _inserted_timestamp
 FROM
-    FINAL
+    flat_responses

--- a/models/silver/defi/bridge/hop/silver_bridge__hop_ammwrapper.sql
+++ b/models/silver/defi/bridge/hop/silver_bridge__hop_ammwrapper.sql
@@ -71,18 +71,18 @@ contract_reads AS (
             [{ 'to': contract_address, 'from': null, 'data': data }, utils.udf_int_to_hex(block_number) ]
         ) AS rpc_request,
         live.udf_api(
-            node_url,
-            rpc_request
+            'POST',
+            CONCAT(
+                '{Service}',
+                '/',
+                '{Authentication}'
+            ),{},
+            rpc_request,
+            'Vault/prod/polygon/quicknode/mainnet'
         ) AS read_output,
         SYSDATE() AS _inserted_timestamp
     FROM
         inputs
-        JOIN {{ source(
-            'streamline_crosschain',
-            'node_mapping'
-        ) }}
-        ON 1 = 1
-        AND chain = 'polygon'
 ),
 reads_flat AS (
     SELECT

--- a/models/silver/defi/bridge/hop/silver_bridge__hop_l2canonicaltoken.sql
+++ b/models/silver/defi/bridge/hop/silver_bridge__hop_l2canonicaltoken.sql
@@ -62,18 +62,18 @@ contract_reads AS (
             [{ 'to': amm_wrapper_address, 'from': null, 'data': data }, utils.udf_int_to_hex(block_number) ]
         ) AS rpc_request,
         live.udf_api(
-            node_url,
-            rpc_request
+            'POST',
+            CONCAT(
+                '{Service}',
+                '/',
+                '{Authentication}'
+            ),{},
+            rpc_request,
+            'Vault/prod/polygon/quicknode/mainnet'
         ) AS read_output,
         SYSDATE() AS _inserted_timestamp
     FROM
         inputs
-        JOIN {{ source(
-            'streamline_crosschain',
-            'node_mapping'
-        ) }}
-        ON 1 = 1
-        AND chain = 'polygon'
 ),
 reads_flat AS (
     SELECT

--- a/models/silver/defi/bridge/stargate/silver_bridge__stargate_createpool.sql
+++ b/models/silver/defi/bridge/stargate/silver_bridge__stargate_createpool.sql
@@ -85,18 +85,18 @@ contract_reads AS (
             [{ 'to': contract_address, 'from': null, 'data': data }, utils.udf_int_to_hex(block_number) ]
         ) AS rpc_request,
         live.udf_api(
-            node_url,
-            rpc_request
+            'POST',
+            CONCAT(
+                '{Service}',
+                '/',
+                '{Authentication}'
+            ),{},
+            rpc_request,
+            'Vault/prod/polygon/quicknode/mainnet'
         ) AS read_output,
         SYSDATE() AS _inserted_timestamp
     FROM
         inputs
-        JOIN {{ source(
-            'streamline_crosschain',
-            'node_mapping'
-        ) }}
-        ON 1 = 1
-        AND chain = 'polygon'
 ),
 reads_flat AS (
     SELECT

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_pools.sql
@@ -85,7 +85,13 @@ tokens_registered AS (
         AND tx_succeeded
 
 {% if is_incremental() %}
-
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+AND _inserted_timestamp >= SYSDATE() - INTERVAL '7 day'
 {% endif %}
 ),
 function_sigs AS (
@@ -105,36 +111,57 @@ inputs_pools AS (
     SELECT
         pool_address,
         block_number,
-        function_sig,
-        (ROW_NUMBER() over (PARTITION BY pool_address
-    ORDER BY
-        block_number)) - 1 AS function_input
+        function_sig
     FROM
         pools_registered
         JOIN function_sigs
         ON 1 = 1
 ),
-pool_token_reads AS ({% for item in range(50) %}
+build_rpc_requests AS (
+    SELECT
+        pool_address,
+        block_number,
+        function_sig,
+        RPAD(
+            function_sig,
+            64,
+            '0'
+        ) AS input,
+        utils.udf_json_rpc_call(
+            'eth_call',
+            [{'to': pool_address, 'from': null, 'data': input}, utils.udf_int_to_hex(block_number)],
+            concat_ws(
+                '-',
+                pool_address,
+                input,
+                block_number
+            )
+        ) AS rpc_request,
+        row_num,
+        CEIL(
+            row_num / 250
+        ) AS batch_no
+    FROM
+        inputs_pools
+        LEFT JOIN pools_registered USING(pool_address)
+),
+pool_token_reads AS ({% for item in range(10) %}
     (
 SELECT
-    ethereum.streamline.udf_json_rpc_read_calls(node_url, headers, PARSE_JSON(batch_read)) AS read_output, SYSDATE() AS _inserted_timestamp
+    live.udf_api('POST', CONCAT('{Service}', '/', '{Authentication}'),{}, batch_rpc_request, 'Vault/prod/polygon/quicknode/mainnet') AS read_output, SYSDATE() AS _inserted_timestamp
 FROM
     (
 SELECT
-    CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+    ARRAY_AGG(rpc_request) batch_rpc_request
 FROM
-    (
-SELECT
-    pool_address, block_number, function_sig, function_input, CONCAT('[\'', pool_address, '\',', block_number, ',\'', function_sig, '\',\'', function_input, '\']') AS read_input, row_num
-FROM
-    inputs_pools
-    LEFT JOIN pools_registered USING(pool_address)) ready_reads_pools
+    build_rpc_requests
 WHERE
-    row_num BETWEEN {{ item * 50 + 1 }}
-    AND {{(item + 1) * 50 }}) batch_reads_pools
-    JOIN {{ source('streamline_crosschain', 'node_mapping') }}
-    ON 1 = 1
-    AND chain = 'polygon') {% if not loop.last %}
+    batch_no = {{ item }} + 1
+    AND batch_no IN (
+SELECT
+    DISTINCT batch_no
+FROM
+    build_rpc_requests))) {% if not loop.last %}
     UNION ALL
     {% endif %}
 {% endfor %}),
@@ -147,14 +174,16 @@ reads_adjusted AS (
             '-'
         ) AS read_id_object,
         read_id_object [0] :: STRING AS pool_address,
-        read_id_object [1] :: STRING AS block_number,
-        read_id_object [2] :: STRING AS function_sig,
-        read_id_object [3] :: STRING AS function_input,
+        LEFT(
+            read_id_object [1] :: STRING,
+            10
+        ) AS function_sig,
+        read_id_object [2] :: STRING AS block_number,
         _inserted_timestamp
     FROM
         pool_token_reads,
         LATERAL FLATTEN(
-            input => read_output [0] :data
+            input => read_output :data
         )
 ),
 pool_details AS (

--- a/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
@@ -199,32 +199,80 @@ all_inputs AS (
     FROM
         inputs_pool_details
 ),
-pool_token_reads AS ({% for item in range(8) %}
+build_rpc_requests AS (
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        function_input,
+        CONCAT(
+            function_sig,
+            LPAD(IFNULL(function_input, 0), 64, '0')
+        ) AS input,
+        utils.udf_json_rpc_call(
+            'eth_call',
+            [{'to': contract_address, 'from': null, 'data':input }, utils.udf_int_to_hex(block_number)],
+            concat_ws(
+                '-',
+                contract_address,
+                input,
+                block_number
+            )
+        ) AS rpc_request,
+        row_num,
+        CEIL(
+            row_num / 50
+        ) AS batch_no
+    FROM
+        all_inputs
+        LEFT JOIN contract_deployments USING(contract_address)
+),
+pool_token_reads AS (
+
+{% if is_incremental() %}
+{% for item in range(6) %}
     (
-SELECT
-    ethereum.streamline.udf_json_rpc_read_calls(node_url, headers, PARSE_JSON(batch_read)) AS read_output, SYSDATE() AS _inserted_timestamp
-FROM
-    (
-SELECT
-    CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
-FROM
-    (
-SELECT
-    deployer_address, contract_address, block_number, function_sig, function_input, CONCAT('[\'', contract_address, '\',', block_number, ',\'', function_sig, '\',\'', (CASE
-    WHEN function_input IS NULL THEN ''
-    ELSE function_input :: STRING END), '\']') AS read_input, row_num
-FROM
-    all_inputs
-    LEFT JOIN contract_deployments USING(contract_address)) ready_reads_pools
-WHERE
-    row_num BETWEEN {{ item * 500 + 1 }}
-    AND {{(item + 1) * 500 }}) batch_reads_pools
-    JOIN {{ source('streamline_crosschain', 'node_mapping') }}
-    ON 1 = 1
-    AND chain = 'polygon') {% if not loop.last %}
-    UNION ALL
-    {% endif %}
-{% endfor %}),
+    SELECT
+        live.udf_api('POST', CONCAT('{Service}', '/', '{Authentication}'),{}, batch_rpc_request, 'Vault/prod/polygon/quicknode/mainnet') AS read_output, SYSDATE() AS _inserted_timestamp
+    FROM
+        (
+    SELECT
+        ARRAY_AGG(rpc_request) batch_rpc_request
+    FROM
+        build_rpc_requests
+    WHERE
+        batch_no = {{ item }} + 1
+        AND batch_no IN (
+    SELECT
+        DISTINCT batch_no
+    FROM
+        build_rpc_requests))) {% if not loop.last %}
+        UNION ALL
+        {% endif %}
+    {% endfor %}
+{% else %}
+    {% for item in range(60) %}
+        (
+    SELECT
+        live.udf_api('POST', CONCAT('{Service}', '/', '{Authentication}'),{}, batch_rpc_request, 'Vault/prod/polygon/quicknode/mainnet') AS read_output, SYSDATE() AS _inserted_timestamp
+    FROM
+        (
+    SELECT
+        ARRAY_AGG(rpc_request) batch_rpc_request
+    FROM
+        build_rpc_requests
+    WHERE
+        batch_no = {{ item }} + 1
+        AND batch_no IN (
+    SELECT
+        DISTINCT batch_no
+    FROM
+        build_rpc_requests))) {% if not loop.last %}
+        UNION ALL
+        {% endif %}
+    {% endfor %}
+{% endif %}),
 reads_adjusted AS (
     SELECT
         VALUE :id :: STRING AS read_id,
@@ -234,14 +282,22 @@ reads_adjusted AS (
             '-'
         ) AS read_id_object,
         read_id_object [0] :: STRING AS contract_address,
-        read_id_object [1] :: STRING AS block_number,
-        read_id_object [2] :: STRING AS function_sig,
-        read_id_object [3] :: STRING AS function_input,
+        read_id_object [2] :: STRING AS block_number,
+        LEFT(
+            read_id_object [1] :: STRING,
+            10
+        ) AS function_sig,
+        RIGHT(
+            read_id_object [1],
+            LENGTH(
+                read_id_object [1] - 10
+            )
+        ) :: INT AS function_input,
         _inserted_timestamp
     FROM
         pool_token_reads,
         LATERAL FLATTEN(
-            input => read_output [0] :data
+            input => read_output :data
         )
 ),
 tokens AS (

--- a/models/silver/protocols/olas/metadata/silver_olas__getservice_reads.sql
+++ b/models/silver/protocols/olas/metadata/silver_olas__getservice_reads.sql
@@ -79,18 +79,18 @@ inputs AS (
                     [{ 'to': contract_address, 'from': null, 'data': data }, utils.udf_int_to_hex(block_number) ]
                 ) AS rpc_request,
                 live.udf_api(
-                    node_url,
-                    rpc_request
+                    'POST',
+                    CONCAT(
+                        '{Service}',
+                        '/',
+                        '{Authentication}'
+                    ),{},
+                    rpc_request,
+                    'Vault/prod/polygon/quicknode/mainnet'
                 ) AS read_output,
                 SYSDATE() AS _inserted_timestamp
             FROM
                 inputs
-                JOIN {{ source(
-                    'streamline_crosschain',
-                    'node_mapping'
-                ) }}
-                ON 1 = 1
-                AND chain = 'polygon'
         ),
         reads_flat AS (
             SELECT

--- a/models/silver/protocols/olas/metadata/silver_olas__registry_reads.sql
+++ b/models/silver/protocols/olas/metadata/silver_olas__registry_reads.sql
@@ -79,18 +79,18 @@ inputs AS (
                     [{ 'to': contract_address, 'from': null, 'data': data }, utils.udf_int_to_hex(block_number) ]
                 ) AS rpc_request,
                 live.udf_api(
-                    node_url,
-                    rpc_request
+                    'POST',
+                    CONCAT(
+                        '{Service}',
+                        '/',
+                        '{Authentication}'
+                    ),{},
+                    rpc_request,
+                    'Vault/prod/polygon/quicknode/mainnet'
                 ) AS read_output,
                 SYSDATE() AS _inserted_timestamp
             FROM
                 inputs
-                JOIN {{ source(
-                    'streamline_crosschain',
-                    'node_mapping'
-                ) }}
-                ON 1 = 1
-                AND chain = 'polygon'
         )
     SELECT
         read_output,


### PR DESCRIPTION
1. Updates the logic to use polygon's LQ deployment rather than ethereum's
2. Restructures models to avoid usage of certain udfs and streamline_crosschain node mapping for secrets